### PR TITLE
Exclude git worktrees, refresh evaluations

### DIFF
--- a/data/evaluations/2026-04-24.json
+++ b/data/evaluations/2026-04-24.json
@@ -1,0 +1,18055 @@
+[
+  {
+    "set_id": "8f2a5c5e8e80",
+    "recipe_type": "download",
+    "app_name": "Anki",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "hansen-m-recipes",
+        "rel_path": "Anki/Anki.download.recipe",
+        "reason": "established since 2013; 2 dependents across 2 repos"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "andrewzirkel-recipes",
+        "rel_path": "Anki/Anki.download.recipe",
+        "reason": "newer duplicate (2016); fewer dependents"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use GitHubReleasesInfoProvider with CodeSignatureVerifier and EndOfCheckPhase, same GitHub source (ankitects/anki)"
+      },
+      {
+        "category": "favors_keep",
+        "text": "2 dependents across 2 repos (dataJAR, nstrauss); established since 2013"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "Only 1 dependent; newer recipe (2016)"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2013-11 vs 2016-08"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to Anki recipes in the hansen-m-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "b4bc0ce021e3",
+    "recipe_type": "download",
+    "app_name": "Arduino",
+    "verdict": "recommend",
+    "confidence": "MEDIUM",
+    "keep": [
+      {
+        "repo": "jps3-recipes",
+        "rel_path": "Arduino/Arduino.download.recipe",
+        "reason": "multi-arch support; oldest recipe (2014); 3 dependents"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "MLBZ521-recipes",
+        "rel_path": "Arduino/Arduino.download.recipe.yaml",
+        "reason": "duplicate with arch support but newer (2023); complex dual-download pattern"
+      },
+      {
+        "repo": "d33t5-recipes",
+        "rel_path": "Arduino/Arduino-Universal.download.recipe.yaml",
+        "reason": "no architecture variable; newer duplicate (2023)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "All use GitHubReleasesInfoProvider with CodeSignatureVerifier from arduino/arduino-ide"
+      },
+      {
+        "category": "favors_keep",
+        "text": "Has ARCHITECTURE input variable; oldest recipe (2014); most dependents (3 across 2 repos)"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "MLBZ521 has complex dual-download for both architectures; d33t5 has no arch variable"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2014-03 vs 2023-09 and 2023-12"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": "keep"
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": "keep"
+      }
+    ],
+    "deprecation_message": "Consider switching to Arduino recipes in the jps3-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "2 child recipe(s) across 2 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "c5e7b89093b0",
+    "recipe_type": "download",
+    "app_name": "balenaEtcher",
+    "verdict": "recommend",
+    "confidence": "MEDIUM",
+    "keep": [
+      {
+        "repo": "dataJAR-recipes",
+        "rel_path": "balenaEtcher/balenaEtcher.download.recipe",
+        "reason": "multi-arch support; 3 dependents"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "andrewvalentine-recipes",
+        "rel_path": "Etcher/Etcher.download.recipe",
+        "reason": "no architecture variable"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase, github source (balena-io/etcher)"
+      },
+      {
+        "category": "favors_keep",
+        "text": "has architecture input variable for arm64/x64 selection"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "no architecture variable"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2018-03 vs 2016-01"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": "keep"
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "deprecate"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to balenaEtcher recipes in the dataJAR-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "5 child recipe(s) across 4 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "f3f4abe2b6a0",
+    "recipe_type": "download",
+    "app_name": "Bambu Studio",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "dataJAR-recipes",
+        "rel_path": "BambuStudio/BambuStudio.download.recipe",
+        "reason": "established since 2018"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "gilburns-recipes",
+        "rel_path": "Bambu Studio/Bambu Studio.download.recipe",
+        "reason": "newer duplicate (since 2024)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase, github source (bambulab/bambustudio)"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2018-03 vs 2024-07"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to Bambu Studio recipes in the dataJAR-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "3 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "f00e9f904e6b",
+    "recipe_type": "download",
+    "app_name": "GitHubCLI",
+    "verdict": "recommend",
+    "confidence": "MEDIUM",
+    "keep": [
+      {
+        "repo": "homebysix-recipes",
+        "rel_path": "GitHub/GitHubCLI.download.recipe",
+        "reason": "multi-arch support"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "dataJAR-recipes",
+        "rel_path": "GitHub CLI/GitHub CLI.download.recipe",
+        "reason": "no architecture variable"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use EndOfCheckPhase, github source (cli/cli)"
+      },
+      {
+        "category": "favors_keep",
+        "text": "has architecture input variable for arm64/x64 selection"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "no architecture variable"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2014-09 vs 2017-01"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": "deprecate"
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": "keep"
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to GitHubCLI recipes in the homebysix-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "e438d62a0d85",
+    "recipe_type": "download",
+    "app_name": "Dangerzone",
+    "verdict": "recommend",
+    "confidence": "HIGH",
+    "keep": [
+      {
+        "repo": "almenscorner-recipes",
+        "rel_path": "Dangerzone/Dangerzone.download.recipe",
+        "reason": "multi-arch support via ARCHITECTURE variable; flexible for both arm64 and x64"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "precursorca-recipes",
+        "rel_path": "Freedom of the Press Foundation/Dangerzone-arm64.download.recipe",
+        "reason": "hardcoded to arm64 only; very new (April 2026)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use GitHubReleasesInfoProvider with CodeSignatureVerifier from freedomofpress/dangerzone"
+      },
+      {
+        "category": "favors_keep",
+        "text": "Has ARCHITECTURE input variable supporting both arm64 and x64"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "Hardcoded to arm64 architecture only; very recently created"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2024-05 vs 2026-04"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": "keep"
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to Dangerzone recipes in the almenscorner-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "50c0df2285e9",
+    "recipe_type": "download",
+    "app_name": "Contour",
+    "verdict": "recommend",
+    "confidence": "MEDIUM",
+    "keep": [
+      {
+        "repo": "jc0b-recipes",
+        "rel_path": "Contour/Contour.download.recipe.yaml",
+        "reason": "Older recipe with version normalization (strips 'v' prefix, converts '-beta' to 'b'); pins release_id to 'latest' for stability"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "kevinmcox-recipes",
+        "rel_path": "Henry Stamerjohann/Contour.download.recipe.yaml",
+        "reason": "Same source, no version normalization; written ~6 weeks after jc0b's recipe"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use GitHubReleasesInfoProvider against headmin/contour with the same asset_regex, both have CodeSignatureVerifier and EndOfCheckPhase, both expect the same Declarative IT GmbH (D6G4X4D7C9) signing identity."
+      },
+      {
+        "category": "favors_keep",
+        "text": "jc0b normalizes the version string via FindAndReplace (strips leading 'v', maps '-beta' to 'b') and explicitly sets release_id='latest' with sort_by_highest_tag_names=true."
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "kevinmcox is a thinner wrapper without version normalization; tag/version output will include the upstream 'v' prefix."
+      },
+      {
+        "category": "tiebreaker",
+        "text": "jc0b first committed 2026-03-07; kevinmcox first committed 2026-04-18 (~6 weeks later)."
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier present",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase present",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "GitHub Releases (resilient)",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Version normalization",
+        "favors": "keep"
+      },
+      {
+        "key": "history",
+        "label": "Earlier first commit",
+        "favors": "keep"
+      }
+    ],
+    "deprecation_message": "Consider switching to Contour recipes in the jc0b-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "none",
+    "existing_prs": []
+  },
+  {
+    "set_id": "f537fb62f033",
+    "recipe_type": "download",
+    "app_name": "JabRef",
+    "verdict": "recommend",
+    "confidence": "HIGH",
+    "keep": [
+      {
+        "repo": "dataJAR-recipes",
+        "rel_path": "JabRef/JabRef.download.recipe",
+        "reason": "multi-arch support; has CodeSignatureVerifier"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "andrewvalentine-recipes",
+        "rel_path": "JabRef/JabRef.download.recipe",
+        "reason": "missing CodeSignatureVerifier; no architecture variable"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use EndOfCheckPhase, github source (jabref/jabref)"
+      },
+      {
+        "category": "favors_keep",
+        "text": "has architecture input variable for arm64/x64 selection; has CodeSignatureVerifier"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "no CodeSignatureVerifier; no architecture variable"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2017-02 vs 2016-01"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": "keep"
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": "keep"
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "deprecate"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to JabRef recipes in the dataJAR-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "327487707720",
+    "recipe_type": "download",
+    "app_name": "Aftermath",
+    "verdict": "skip",
+    "skip_reason": "different products (Aftermath installer vs AftermathUninstaller are separate release assets; dataJAR recipe downloads both)"
+  },
+  {
+    "set_id": "57977624d114",
+    "recipe_type": "download",
+    "app_name": "macOSLAPS",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "neilmartin83-recipes",
+        "rel_path": "macOSLAPS/macOSLAPS.download.recipe.yaml",
+        "reason": "3 dependents"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "grahampugh-recipes",
+        "rel_path": "macOSLAPS/macOSLAPS3.download.recipe.yaml",
+        "reason": "functionally equivalent duplicate"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase, github source (joshua-d-miller/macoslaps)"
+      },
+      {
+        "category": "favors_keep",
+        "text": "3 dependent recipes"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2025-01 vs 2022-07"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "deprecate"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to macOSLAPS recipes in the neilmartin83-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "adf849d2c2cf",
+    "recipe_type": "download",
+    "app_name": "KeyStoreExplorer",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "dataJAR-recipes",
+        "rel_path": "KeyStore Explorer/KeyStore Explorer.download.recipe",
+        "reason": "established since 2017"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "peshay-recipes",
+        "rel_path": "keystore-explorer/keystore-explorer.download.recipe",
+        "reason": "newer duplicate (since 2018)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase, github source (kaikramer/keystore-explorer)"
+      },
+      {
+        "category": "favors_keep",
+        "text": "2 dependent recipes"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2017-01 vs 2018-09"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to KeyStoreExplorer recipes in the dataJAR-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "8856528d651b",
+    "recipe_type": "download",
+    "app_name": "dockutil/",
+    "verdict": "recommend",
+    "confidence": "HIGH",
+    "keep": [
+      {
+        "repo": "jessepeterson-recipes",
+        "rel_path": "dockutil/dockutil.download.recipe",
+        "reason": "has CodeSignatureVerifier; 5 dependents"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "andrewzirkel-recipes",
+        "rel_path": "dockutil/dockutil.download.recipe",
+        "reason": "missing CodeSignatureVerifier"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use EndOfCheckPhase, github source (kcrawford/dockutil)"
+      },
+      {
+        "category": "favors_keep",
+        "text": "has CodeSignatureVerifier; 5 dependent recipes"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "no CodeSignatureVerifier"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2016-01 vs 2022-05"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": "keep"
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to dockutil/ recipes in the jessepeterson-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "04095b9b5771",
+    "recipe_type": "download",
+    "app_name": "KeePassXC",
+    "verdict": "recommend",
+    "confidence": "MEDIUM",
+    "keep": [
+      {
+        "repo": "n8felton-recipes",
+        "rel_path": "KeePassXC/KeePassXC.download.recipe",
+        "reason": "multi-arch support; 5 dependents"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "dataJAR-recipes",
+        "rel_path": "KeePassXC/KeePassXC.download.recipe",
+        "reason": "newer duplicate (since 2019)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase, github source (keepassxreboot/keepassxc)"
+      },
+      {
+        "category": "favors_keep",
+        "text": "5 dependent recipes"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2016-08 vs 2019-07"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to KeePassXC recipes in the n8felton-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "3ae33726dc22",
+    "recipe_type": "download",
+    "app_name": "Vysor",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "dataJAR-recipes",
+        "rel_path": "Vysor/Vysor.download.recipe",
+        "reason": "established since 2018"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "ahousseini-recipes",
+        "rel_path": "Vysor/Vysor.download.recipe",
+        "reason": "newer duplicate (since 2020)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase, github source (koush/vysor.io)"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2018-03 vs 2020-05"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to Vysor recipes in the dataJAR-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "4254821ed59f",
+    "recipe_type": "download",
+    "app_name": "kitty",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "jaharmi-recipes",
+        "rel_path": "KovidGoyal/kitty.download.recipe",
+        "reason": "3 dependents"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "apizz-recipes",
+        "rel_path": "Kitty/Kitty.download.recipe",
+        "reason": "newer duplicate (since 2018)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase, github source (kovidgoyal/kitty)"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2015-12 vs 2018-03"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to kitty recipes in the jaharmi-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "3 child recipe(s) across 2 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "a2d98879f657",
+    "recipe_type": "download",
+    "app_name": "Logseq",
+    "verdict": "recommend",
+    "confidence": "MEDIUM",
+    "keep": [
+      {
+        "repo": "w0-recipes",
+        "rel_path": "Logseq/Logseq.download.recipe.yaml",
+        "reason": "multi-arch support"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "jaharmi-recipes",
+        "rel_path": "Logseq/Logseq.download.recipe",
+        "reason": "no architecture variable"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase, github source (logseq/logseq)"
+      },
+      {
+        "category": "favors_keep",
+        "text": "has architecture input variable for arm64/x64 selection"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "no architecture variable"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2022-08 vs 2015-12"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": "keep"
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "deprecate"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": "deprecate"
+      }
+    ],
+    "deprecation_message": "Consider switching to Logseq recipes in the w0-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "3 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "3e46442038f0",
+    "recipe_type": "download",
+    "app_name": "Nudge",
+    "verdict": "recommend",
+    "confidence": "MEDIUM",
+    "keep": [
+      {
+        "repo": "erikng-recipes",
+        "rel_path": "Nudge/Nudge.download.recipe",
+        "reason": "original recipe by Nudge developer; 3 dependents across 3 repos"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "aanklewicz-recipes",
+        "rel_path": "NudgeLogger/NudgeLogger.download.recipe",
+        "reason": "functionally identical duplicate; newer (2025 vs 2021)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use GitHubReleasesInfoProvider with CodeSignatureVerifier, same source and identical asset_regex pattern"
+      },
+      {
+        "category": "favors_keep",
+        "text": "Original recipe by Nudge developer Erik Gomez; established since 2021 with 3 dependents"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "NudgeLogger is a near-identical copy with different naming; created 2025"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2021-02 vs 2025-02"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to Nudge recipes in the erikng-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "f207706df597",
+    "recipe_type": "download",
+    "app_name": "Mattermost",
+    "verdict": "recommend",
+    "confidence": "MEDIUM",
+    "keep": [
+      {
+        "repo": "peshay-recipes",
+        "rel_path": "Mattermost/Mattermost.download.recipe",
+        "reason": "has CodeSignatureVerifier"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "ygini-recipes",
+        "rel_path": "Mattermost/Mattermost.download.recipe",
+        "reason": "missing CodeSignatureVerifier"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use EndOfCheckPhase, github source (mattermost/desktop)"
+      },
+      {
+        "category": "favors_keep",
+        "text": "has CodeSignatureVerifier"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "no CodeSignatureVerifier"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2016-09 vs 2021-01"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": "keep"
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to Mattermost recipes in the peshay-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "3 child recipe(s) across 3 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "5bf5fa58829f",
+    "recipe_type": "download",
+    "app_name": "Franz",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "andrewvalentine-recipes",
+        "rel_path": "Franz/Franz.download.recipe",
+        "reason": "3 dependents"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "faumac-recipes",
+        "rel_path": "Franz/Franz.download.recipe",
+        "reason": "newer duplicate (since 2019)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase, github source (meetfranz/franz)"
+      },
+      {
+        "category": "favors_keep",
+        "text": "3 dependent recipes"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2016-01 vs 2019-09"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to Franz recipes in the andrewvalentine-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "2 child recipe(s) across 2 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "c75b82c6ddc8",
+    "recipe_type": "download",
+    "app_name": "PowerShell",
+    "verdict": "recommend",
+    "confidence": "MEDIUM",
+    "keep": [
+      {
+        "repo": "vmiller-recipes",
+        "rel_path": "PowerShell/PowerShell.download.recipe",
+        "reason": "multi-arch support; release channel variable; 4 dependents"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "smithjw-recipes",
+        "rel_path": "PowerShell/PowerShell-Universal.download.recipe.yaml",
+        "reason": "no architecture variable"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase, github source (powershell/powershell)"
+      },
+      {
+        "category": "favors_keep",
+        "text": "has architecture input variable for arm64/x64 selection; 4 dependent recipes"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "no architecture variable"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2015-03 vs 2022-09"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": "keep"
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": "keep"
+      }
+    ],
+    "deprecation_message": "Consider switching to PowerShell recipes in the vmiller-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "7430c358431a",
+    "recipe_type": "download",
+    "app_name": "Support",
+    "verdict": "skip",
+    "skip_reason": "different formats (PKG vs ZIP downloads from same source); paul-cossey has both PKG and ZIP variants"
+  },
+  {
+    "set_id": "0e123552c2b4",
+    "recipe_type": "download",
+    "app_name": "Support Helper",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "grahampugh-recipes",
+        "rel_path": "SupportApp/SupportHelper.download.recipe.yaml",
+        "reason": "established since 2021"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "paul-cossey-recipes",
+        "rel_path": "Support/SupportHelper.download.recipe",
+        "reason": "newer duplicate (since 2022)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase, github source (root3nl/supportapp)"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2021-08 vs 2022-03"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": "deprecate"
+      }
+    ],
+    "deprecation_message": "Consider switching to Support Helper recipes in the grahampugh-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "d7ddc769e02b",
+    "recipe_type": "download",
+    "app_name": "step",
+    "verdict": "recommend",
+    "confidence": "MEDIUM",
+    "keep": [
+      {
+        "repo": "fishd72-recipes",
+        "rel_path": "Smallstep/step_cli.download.recipe",
+        "reason": "multi-arch support"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "Lotusshaney-recipes",
+        "rel_path": "SmallStep/step_cli_uni.download.recipe",
+        "reason": "no architecture variable"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use EndOfCheckPhase, github source (smallstep/cli)"
+      },
+      {
+        "category": "favors_keep",
+        "text": "has architecture input variable for arm64/x64 selection"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "no architecture variable"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2018-11 vs 2024-04"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": "deprecate"
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": "keep"
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to step recipes in the fishd72-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "c93663f2d189",
+    "recipe_type": "download",
+    "app_name": "Ultimaker Cura",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "dataJAR-recipes",
+        "rel_path": "Ultimaker Cura/Ultimaker Cura.download.recipe",
+        "reason": "multi-arch support"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "MLBZ521-recipes",
+        "rel_path": "Ultimaker Cura/UltimakerCura-Universal.download.recipe.yaml",
+        "reason": "newer duplicate (since 2024)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase, github source (ultimaker/cura)"
+      },
+      {
+        "category": "favors_keep",
+        "text": "2 dependent recipes"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2018-03 vs 2024-08"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": "keep"
+      }
+    ],
+    "deprecation_message": "Consider switching to Ultimaker Cura recipes in the dataJAR-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "54d6c1446355",
+    "recipe_type": "download",
+    "app_name": "Adapter",
+    "verdict": "recommend",
+    "confidence": "MEDIUM",
+    "keep": [
+      {
+        "repo": "homebysix-recipes",
+        "rel_path": "Macroplant/Adapter.download.recipe",
+        "reason": "3 dependents"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "ahousseini-recipes",
+        "rel_path": "Adapter/Adapter.download.recipe",
+        "reason": "newer duplicate (since 2020)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "more resilient source (url vs unknown); 3 dependent recipes"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "less resilient source (unknown)"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2014-09 vs 2020-05"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": "keep"
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to Adapter recipes in the homebysix-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "3fe55c563a16",
+    "recipe_type": "download",
+    "app_name": "AdobeAcrobatPro",
+    "verdict": "recommend",
+    "confidence": "HIGH",
+    "keep": [
+      {
+        "repo": "moofit-recipes",
+        "rel_path": "Adobe/AdobeAcrobatPro.download.recipe.yaml",
+        "reason": "has CodeSignatureVerifier; simpler and more maintainable approach"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "mosen-recipes",
+        "rel_path": "Adobe/AdobeAcrobatProBase.download.recipe",
+        "reason": "no CodeSignatureVerifier; uses cookie headers and complex pkg extraction"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both download Adobe Acrobat Pro from Adobe's trials CDN"
+      },
+      {
+        "category": "favors_keep",
+        "text": "Has CodeSignatureVerifier; cleaner recipe with fewer processors"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "No CodeSignatureVerifier; requires cookie headers; complex FlatPkgUnpacker/PkgPayloadUnpacker chain"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "mosen recipe is older (2017 vs 2023) but lacks modern best practices"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": "keep"
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": "deprecate"
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "deprecate"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": "deprecate"
+      }
+    ],
+    "deprecation_message": "Consider switching to AdobeAcrobatPro recipes in the moofit-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "d597367390ec",
+    "recipe_type": "download",
+    "app_name": "Affinity Designer",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "peterkelm-recipes",
+        "rel_path": "Serif/AffinityDesigner.download.recipe",
+        "reason": "3 dependents"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "faumac-recipes",
+        "rel_path": "Affinity Designer/Affinity Designer.download.recipe",
+        "reason": "newer duplicate (since 2019)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "3 dependent recipes"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to Affinity Designer recipes in the peterkelm-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "bbcf43e8a24f",
+    "recipe_type": "download",
+    "app_name": "Affinity Photo",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "peterkelm-recipes",
+        "rel_path": "Serif/AffinityPhoto.download.recipe",
+        "reason": "3 dependents"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "faumac-recipes",
+        "rel_path": "Affinity Photo/Affinity Photo.download.recipe",
+        "reason": "newer duplicate (since 2019)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "3 dependent recipes"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to Affinity Photo recipes in the peterkelm-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "069af748c779",
+    "recipe_type": "download",
+    "app_name": "Affinity Publisher",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "peterkelm-recipes",
+        "rel_path": "Serif/AffinityPublisher.download.recipe",
+        "reason": "3 dependents"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "faumac-recipes",
+        "rel_path": "Affinity Publisher/Affinity Publisher.download.recipe",
+        "reason": "newer duplicate (since 2019)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "3 dependent recipes"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to Affinity Publisher recipes in the peterkelm-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "ff272487e933",
+    "recipe_type": "download",
+    "app_name": "Airtame",
+    "verdict": "skip",
+    "skip_reason": "different formats (DMG vs PKG from same vendor)"
+  },
+  {
+    "set_id": "6313b4597c26",
+    "recipe_type": "download",
+    "app_name": "AmadeusLite",
+    "verdict": "recommend",
+    "confidence": "MEDIUM",
+    "keep": [
+      {
+        "repo": "jazzace-recipes",
+        "rel_path": "HairerSoft/AmadeusLite.download.recipe",
+        "reason": "established since 2020"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "timsutton-recipes",
+        "rel_path": "HairerSoft/AmadeusLite.download.recipe",
+        "reason": "functionally equivalent duplicate"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "more resilient source (url vs unknown)"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "less resilient source (unknown)"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2020-04 vs 2013-11"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": "keep"
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "deprecate"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to AmadeusLite recipes in the jazzace-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "b65ba16940c5",
+    "recipe_type": "download",
+    "app_name": "Amazon Chime",
+    "verdict": "recommend",
+    "confidence": "MEDIUM",
+    "keep": [
+      {
+        "repo": "dbergstrom-recipes",
+        "rel_path": "Amazon Chime/Amazon Chime.download.recipe",
+        "reason": "3 dependents"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "moofit-recipes",
+        "rel_path": "Amazon/AmazonChime.download.recipe",
+        "reason": "functionally equivalent duplicate"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "more resilient source (sparkle vs url)"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "less resilient source (url)"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2022-03 vs 2017-06"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": "keep"
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "deprecate"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to Amazon Chime recipes in the dbergstrom-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "3 child recipe(s) across 3 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "0625e4bea008",
+    "recipe_type": "download",
+    "app_name": "AmazonCorretto%MAJOR_VERSION%",
+    "verdict": "recommend",
+    "confidence": "MEDIUM",
+    "keep": [
+      {
+        "repo": "aws-recipes",
+        "rel_path": "Corretto/AmazonCorrettoJDK.download.recipe",
+        "reason": "official AWS-maintained recipe with CorrettoURLProvider; 3 dependents"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "dataJAR-recipes",
+        "rel_path": "Amazon Corretto/Amazon Corretto.download.recipe",
+        "reason": "uses hardcoded URL pattern; duplicate of official recipe"
+      },
+      {
+        "repo": "n8felton-recipes",
+        "rel_path": "Amazon/AmazonCorretto.download.recipe",
+        "reason": "uses hardcoded URL pattern; duplicate of official recipe"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "All support architecture and major version selection with CodeSignatureVerifier"
+      },
+      {
+        "category": "favors_keep",
+        "text": "Official AWS-maintained recipe with dedicated CorrettoURLProvider processor; 3 dependents"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "Use hardcoded URL patterns that may break if AWS changes download paths"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "aws repo established 2022, dataJAR 2018, n8felton 2019"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to AmazonCorretto%MAJOR_VERSION% recipes in the aws-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "4 child recipe(s) across 2 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "3069bb80be43",
+    "recipe_type": "download",
+    "app_name": "AppleSupportArticle",
+    "verdict": "skip",
+    "skip_reason": "different products (davidbpirie downloads linked software from article; jazzace downloads the article HTML itself)"
+  },
+  {
+    "set_id": "23e568116422",
+    "recipe_type": "download",
+    "app_name": "Bartender",
+    "verdict": "recommend",
+    "confidence": "HIGH",
+    "keep": [
+      {
+        "repo": "homebysix-recipes",
+        "rel_path": "Bartender/Bartender.download.recipe",
+        "reason": "release channel variable; has CodeSignatureVerifier; 4 dependents"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "keeleysam-recipes",
+        "rel_path": "SurteesStudios/Bartender.download.recipe",
+        "reason": "missing CodeSignatureVerifier; no release variable"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "has release channel input variable; has CodeSignatureVerifier; 4 dependent recipes"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "no CodeSignatureVerifier; no release variable"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2014-09 vs 2015-12"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": "keep"
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": "keep"
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to Bartender recipes in the homebysix-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "190a6e4820ea",
+    "recipe_type": "download",
+    "app_name": "Basecamp3",
+    "verdict": "recommend",
+    "confidence": "MEDIUM",
+    "keep": [
+      {
+        "repo": "almenscorner-recipes",
+        "rel_path": "Basecamp 3/Basecamp 3.download.recipe",
+        "reason": "multi-arch support"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "jessepeterson-recipes",
+        "rel_path": "Basecamp/Basecamp3.download.recipe",
+        "reason": "no architecture variable"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "has architecture input variable for arm64/x64 selection"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "no architecture variable"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2025-03 vs 2017-05"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": "keep"
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "deprecate"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to Basecamp3 recipes in the almenscorner-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "2 child recipe(s) across 2 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "ea1749a53e73",
+    "recipe_type": "download",
+    "app_name": "BasicTeX",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "andrewvalentine-recipes",
+        "rel_path": "BasicTeX/BasicTeX.download.recipe",
+        "reason": "established since 2016"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "grahampugh-recipes",
+        "rel_path": "TeX/BasicTeX.download.recipe.yaml",
+        "reason": "newer duplicate (since 2018)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2016-01 vs 2018-10"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": "keep"
+      }
+    ],
+    "deprecation_message": "Consider switching to BasicTeX recipes in the andrewvalentine-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "370be57abf20",
+    "recipe_type": "download",
+    "app_name": "BeyondCompare4",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "dataJAR-recipes",
+        "rel_path": "Beyond Compare 4/Beyond Compare 4.download.recipe",
+        "reason": "established since 2018"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "blackthroat-recipes",
+        "rel_path": "Scooter Software, Inc./BeyondCompare4.download.recipe",
+        "reason": "newer duplicate (since 2019)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2018-03 vs 2019-09"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to BeyondCompare4 recipes in the dataJAR-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "2 child recipe(s) across 2 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "c071bb6fec33",
+    "recipe_type": "download",
+    "app_name": "Bitwarden",
+    "verdict": "recommend",
+    "confidence": "HIGH",
+    "keep": [
+      {
+        "repo": "drewdiver-recipes",
+        "rel_path": "Bitwarden/Bitwarden.download.recipe",
+        "reason": "uses current bitwarden/clients monorepo; 3 dependents across 3 repos"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "blackthroat-recipes",
+        "rel_path": "8bit Solutions LLC/Bitwarden.download.recipe",
+        "reason": "uses deprecated bitwarden/desktop repo which may stop receiving releases"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use GitHubReleasesInfoProvider with CodeSignatureVerifier to download Bitwarden DMG"
+      },
+      {
+        "category": "favors_keep",
+        "text": "Uses current bitwarden/clients monorepo (where Bitwarden actively publishes releases); 3 dependents"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "Uses deprecated bitwarden/desktop repo; Bitwarden has migrated to clients monorepo"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "blackthroat is older (2017) but points to deprecated source"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": "keep"
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "deprecate"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to Bitwarden recipes in the drewdiver-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "3 child recipe(s) across 3 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "02d0c04ffa7d",
+    "recipe_type": "download",
+    "app_name": "BlueJ",
+    "verdict": "recommend",
+    "confidence": "HIGH",
+    "keep": [
+      {
+        "repo": "n8felton-recipes",
+        "rel_path": "BlueJ/BlueJ.download.recipe",
+        "reason": "multi-arch support; 3 dependents"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "orchard-recipes",
+        "rel_path": "BlueJ/BlueJ.download.recipe",
+        "reason": "no architecture variable"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "has architecture input variable for arm64/x64 selection; more resilient source (github vs url); 3 dependent recipes"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "no architecture variable; less resilient source (url)"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2016-07 vs 2015-11"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": "keep"
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": "keep"
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "deprecate"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to BlueJ recipes in the n8felton-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "2 child recipe(s) across 2 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "99c0d662ded3",
+    "recipe_type": "download",
+    "app_name": "Bria",
+    "verdict": "recommend",
+    "confidence": "MEDIUM",
+    "keep": [
+      {
+        "repo": "dataJAR-recipes",
+        "rel_path": "Bria/Bria.download.recipe",
+        "reason": "established since 2019"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "ahousseini-recipes",
+        "rel_path": "Bria/Bria.download.recipe",
+        "reason": "newer duplicate (since 2020)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "more resilient source (url vs unknown)"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "less resilient source (unknown)"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2019-11 vs 2020-05"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": "keep"
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to Bria recipes in the dataJAR-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "fb3b8571f113",
+    "recipe_type": "download",
+    "app_name": "BusyCal",
+    "verdict": "skip",
+    "skip_reason": "different formats (ZIP containing PKG installer vs DMG containing app bundle)"
+  },
+  {
+    "set_id": "de9d8e2eb194",
+    "recipe_type": "download",
+    "app_name": "Callbar",
+    "verdict": "recommend",
+    "confidence": "MEDIUM",
+    "keep": [
+      {
+        "repo": "dataJAR-recipes",
+        "rel_path": "Callbar/Callbar.download.recipe",
+        "reason": "established since 2018"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "ahousseini-recipes",
+        "rel_path": "Callbar/Callbar.download.recipe",
+        "reason": "newer duplicate (since 2020)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "more resilient source (url vs unknown); 2 dependent recipes"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "less resilient source (unknown)"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2018-03 vs 2020-05"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": "keep"
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to Callbar recipes in the dataJAR-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "none",
+    "existing_prs": []
+  },
+  {
+    "set_id": "50e8a175ad61",
+    "recipe_type": "download",
+    "app_name": "Chromium",
+    "verdict": "recommend",
+    "confidence": "MEDIUM",
+    "keep": [
+      {
+        "repo": "dataJAR-recipes",
+        "rel_path": "Chromium/Chromium.download.recipe",
+        "reason": "multi-arch support"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "ahousseini-recipes",
+        "rel_path": "Chromium/Chromium.download.recipe",
+        "reason": "no architecture variable"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "has architecture input variable for arm64/x64 selection"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "no architecture variable"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2020-03 vs 2020-05"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": "deprecate"
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": "keep"
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to Chromium recipes in the dataJAR-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "9469271f4047",
+    "recipe_type": "download",
+    "app_name": "Cinemagraph Pro",
+    "verdict": "recommend",
+    "confidence": "MEDIUM",
+    "keep": [
+      {
+        "repo": "swy-recipes",
+        "rel_path": "Flixel Photos Inc./CinemagraphPro.download.recipe",
+        "reason": "3 dependents"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "n8felton-recipes",
+        "rel_path": "Flixel/Cinemagraph Pro.download.recipe",
+        "reason": "newer duplicate (since 2016)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "more resilient source (sparkle vs unknown)"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "less resilient source (unknown)"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2015-11 vs 2016-10"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": "keep"
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to Cinemagraph Pro recipes in the swy-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "3 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "b6de2c69ddc0",
+    "recipe_type": "download",
+    "app_name": "Cisco Jabber",
+    "verdict": "recommend",
+    "confidence": "MEDIUM",
+    "keep": [
+      {
+        "repo": "joshua-d-miller-recipes",
+        "rel_path": "Cisco/CiscoJabber.download.recipe",
+        "reason": "established since 2019"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "ahousseini-recipes",
+        "rel_path": "Cisco Jabber/Cisco Jabber.download.recipe",
+        "reason": "newer duplicate (since 2020)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "more resilient source (url vs unknown); 2 dependent recipes"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "less resilient source (unknown)"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2019-07 vs 2020-05"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": "keep"
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to Cisco Jabber recipes in the joshua-d-miller-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "a567509dc38c",
+    "recipe_type": "download",
+    "app_name": "ClamXAV",
+    "verdict": "recommend",
+    "confidence": "MEDIUM",
+    "keep": [
+      {
+        "repo": "homebysix-recipes",
+        "rel_path": "ClamXav/ClamXav.download.recipe",
+        "reason": "established since 2015"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "jessepeterson-recipes",
+        "rel_path": "ClamXav/ClamXav.download.recipe",
+        "reason": "newer duplicate (since 2016)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "more resilient source (sparkle vs url); 2 dependent recipes"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "less resilient source (url)"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2015-08 vs 2016-07"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": "keep"
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to ClamXAV recipes in the homebysix-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "9c98d1a0f0e3",
+    "recipe_type": "download",
+    "app_name": "ClickUp",
+    "verdict": "recommend",
+    "confidence": "MEDIUM",
+    "keep": [
+      {
+        "repo": "dataJAR-recipes",
+        "rel_path": "ClickUp/ClickUp.download.recipe",
+        "reason": "multi-arch support"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "moofit-recipes",
+        "rel_path": "ClickUp/ClickUp.download.recipe.yaml",
+        "reason": "no architecture variable"
+      },
+      {
+        "repo": "andredb90-recipes",
+        "rel_path": "ClickUp/ClickUp.download.recipe",
+        "reason": "no architecture variable"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "has architecture input variable for arm64/x64 selection; more resilient source (url vs None); 2 dependent recipes"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "no architecture variable"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "no architecture variable; less resilient source (None)"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2017-01 vs 2022-05"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2017-01 vs 2019-08"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": "keep"
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": "keep"
+      }
+    ],
+    "deprecation_message": "Consider switching to ClickUp recipes in the dataJAR-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "2 child recipe(s) across 2 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "f11188f2cd82",
+    "recipe_type": "download",
+    "app_name": "CLion",
+    "verdict": "recommend",
+    "confidence": "MEDIUM",
+    "keep": [
+      {
+        "repo": "gregneagle-recipes",
+        "rel_path": "CLion/CLion.download.recipe",
+        "reason": "3 dependents"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "chilcote-recipes",
+        "rel_path": "JetBrains/CLion.download.recipe",
+        "reason": "newer duplicate (since 2016)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "more resilient source (url vs unknown); 3 dependent recipes"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "less resilient source (unknown)"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2015-11 vs 2016-07"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": "keep"
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to CLion recipes in the gregneagle-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "0dda4ef4c05b",
+    "recipe_type": "download",
+    "app_name": "CloudApp",
+    "verdict": "recommend",
+    "confidence": "MEDIUM",
+    "keep": [
+      {
+        "repo": "dataJAR-recipes",
+        "rel_path": "CloudApp/CloudApp.download.recipe",
+        "reason": "established since 2019"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "psaintemarie-recipes",
+        "rel_path": "CloudApp/CloudApp.download.recipe",
+        "reason": "newer duplicate (since 2019)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "more resilient source (sparkle vs url); 2 dependent recipes"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "less resilient source (url)"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2019-04 vs 2019-10"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": "keep"
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to CloudApp recipes in the dataJAR-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "bbf12a11d83f",
+    "recipe_type": "download",
+    "app_name": "Cloudflare WARP",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "haircut-recipes",
+        "rel_path": "Cloudflare/CloudflareWARPTeams.download.recipe",
+        "reason": "established since 2023"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "mikestechshop-recipes",
+        "rel_path": "CloudFlare/CloudFlareWarp.download.recipe",
+        "reason": "functionally equivalent duplicate"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "more resilient source (sparkle vs url)"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "less resilient source (url)"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2023-12 vs 2020-10"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": "keep"
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "deprecate"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to Cloudflare WARP recipes in the haircut-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "3 child recipe(s) across 3 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "8803159b5889",
+    "recipe_type": "download",
+    "app_name": "Comic Life",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "ahousseini-recipes",
+        "rel_path": "Comic Life/Comic Life.download.recipe",
+        "reason": "has CodeSignatureVerifier"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "andrewzirkel-recipes",
+        "rel_path": "Comic Life 3/Comic Life 3.download.recipe",
+        "reason": "newer duplicate (since 2021)"
+      },
+      {
+        "repo": "homebysix-recipes",
+        "rel_path": "ComicLife/ComicLife.download.recipe",
+        "reason": "missing CodeSignatureVerifier"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "has CodeSignatureVerifier; more resilient source (sparkle vs url)"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "no CodeSignatureVerifier; less resilient source (url)"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2020-05 vs 2021-03"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2020-05 vs 2014-09"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": "keep"
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "deprecate"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to Comic Life recipes in the ahousseini-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "2 child recipe(s) across 2 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "a6ef14749155",
+    "recipe_type": "download",
+    "app_name": "Composer",
+    "verdict": "skip",
+    "skip_reason": "different products (Jamf Pro Composer vs PHP Composer command line tool)"
+  },
+  {
+    "set_id": "888fd9041e40",
+    "recipe_type": "download",
+    "app_name": "CrashPlan",
+    "verdict": "skip",
+    "skip_reason": "different platforms (Mac DMG vs Linux .tgz)"
+  },
+  {
+    "set_id": "f59f9692643b",
+    "recipe_type": "download",
+    "app_name": "Cryptomator",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "ahousseini-recipes",
+        "rel_path": "Cryptomator/Cryptomator.download.recipe",
+        "reason": "multi-arch support"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "joshua-d-miller-recipes",
+        "rel_path": "Skymatic/Cryptomator.download.recipe",
+        "reason": "no architecture variable"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "has architecture input variable for arm64/x64 selection"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "no architecture variable"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2020-05 vs 2019-07"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": "keep"
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "deprecate"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to Cryptomator recipes in the ahousseini-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "2 child recipe(s) across 2 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "98cca5424633",
+    "recipe_type": "download",
+    "app_name": "Dash",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "hjuutilainen-recipes",
+        "rel_path": "Kapeli/Dash.download.recipe",
+        "reason": "release channel variable"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "andrewvalentine-recipes",
+        "rel_path": "dash/dash.download.recipe",
+        "reason": "no release variable"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "has release channel input variable"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "no release variable"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2013-09 vs 2016-01"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": "keep"
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to Dash recipes in the hjuutilainen-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "3 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "adc9d93c5678",
+    "recipe_type": "download",
+    "app_name": "DCPomatic2",
+    "verdict": "recommend",
+    "confidence": "HIGH",
+    "keep": [
+      {
+        "repo": "dataJAR-recipes",
+        "rel_path": "DCP-o-matic 2/DCP-o-matic 2.download.recipe",
+        "reason": "has CodeSignatureVerifier"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "timsutton-recipes",
+        "rel_path": "DCP-o-matic/DCPomatic2.download.recipe",
+        "reason": "missing CodeSignatureVerifier"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "has CodeSignatureVerifier; more resilient source (url vs unknown)"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "no CodeSignatureVerifier; less resilient source (unknown)"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2018-03 vs 2017-07"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": "keep"
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": "deprecate"
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": "keep"
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "deprecate"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to DCPomatic2 recipes in the dataJAR-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "fe9d920373f1",
+    "recipe_type": "download",
+    "app_name": "DeepL",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "andredb90-recipes",
+        "rel_path": "DeepL/DeepL.download.recipe",
+        "reason": "3 dependents"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "macprince-recipes",
+        "rel_path": "DeepL/DeepL.download.recipe",
+        "reason": "functionally equivalent duplicate"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "more resilient source (sparkle vs url)"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "less resilient source (url)"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2019-08 vs 2017-03"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": "keep"
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "deprecate"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to DeepL recipes in the andredb90-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "4 child recipe(s) across 2 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "51ab490fcac2",
+    "recipe_type": "download",
+    "app_name": "defaultbrowser",
+    "verdict": "recommend",
+    "confidence": "HIGH",
+    "keep": [
+      {
+        "repo": "haircut-recipes",
+        "rel_path": "macadmins/default-browser.download.recipe",
+        "reason": "has CodeSignatureVerifier; actively maintained macadmins fork"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "apizz-recipes",
+        "rel_path": "defaultbrowser/defaultbrowser.download.recipe",
+        "reason": "no CodeSignatureVerifier; uses older kerma/defaultbrowser repo"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both are command-line utilities for setting the default browser on macOS"
+      },
+      {
+        "category": "favors_keep",
+        "text": "Has CodeSignatureVerifier; uses macadmins/default-browser which is actively maintained"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "No CodeSignatureVerifier; uses kerma/defaultbrowser which is the original but less maintained"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": "keep"
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "deprecate"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to defaultbrowser recipes in the haircut-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "6ed3a4ba4ec5",
+    "recipe_type": "download",
+    "app_name": "DEPNotify",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "rderewianko-recipes",
+        "rel_path": "DEPNotify/DEPNotify.download.recipe",
+        "reason": "3 dependents"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "moofit-recipes",
+        "rel_path": "Orchard and Grove/DEPNotify.download.recipe",
+        "reason": "newer duplicate (since 2018)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "3 dependent recipes"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2018-04 vs 2018-05"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to DEPNotify recipes in the rderewianko-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "8539e16348fd",
+    "recipe_type": "download",
+    "app_name": "DEVONthink",
+    "verdict": "recommend",
+    "confidence": "MEDIUM",
+    "keep": [
+      {
+        "repo": "dataJAR-recipes",
+        "rel_path": "DEVONthink/DEVONthink.download.recipe",
+        "reason": "established since 2018"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "ahousseini-recipes",
+        "rel_path": "DEVONthink/DEVONthink.download.recipe",
+        "reason": "newer duplicate (since 2020)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "more resilient source (sparkle vs unknown)"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "less resilient source (unknown)"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2018-03 vs 2020-05"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": "keep"
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to DEVONthink recipes in the dataJAR-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "830c007dc9bc",
+    "recipe_type": "download",
+    "app_name": "DHS",
+    "verdict": "recommend",
+    "confidence": "MEDIUM",
+    "keep": [
+      {
+        "repo": "dataJAR-recipes",
+        "rel_path": "DHS/DHS.download.recipe",
+        "reason": "established since 2018"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "ahousseini-recipes",
+        "rel_path": "DHS/DHS.download.recipe",
+        "reason": "newer duplicate (since 2020)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "more resilient source (url vs unknown)"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "less resilient source (unknown)"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2018-03 vs 2020-05"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": "keep"
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to DHS recipes in the dataJAR-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "a837ba032399",
+    "recipe_type": "download",
+    "app_name": "DiskDrill",
+    "verdict": "recommend",
+    "confidence": "MEDIUM",
+    "keep": [
+      {
+        "repo": "homebysix-recipes",
+        "rel_path": "DiskDrill/DiskDrill.download.recipe",
+        "reason": "3 dependents"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "hjuutilainen-recipes",
+        "rel_path": "CleverFiles/DiskDrill.download.recipe",
+        "reason": "functionally equivalent duplicate"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "more resilient source (sparkle vs url)"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "less resilient source (url)"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2015-08 vs 2013-09"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": "keep"
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "deprecate"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to DiskDrill recipes in the homebysix-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "3 child recipe(s) across 2 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "6243a321455c",
+    "recipe_type": "download",
+    "app_name": "Docker",
+    "verdict": "skip",
+    "skip_reason": "different channels and formats (Docker Edge vs Docker Desktop stable; multiple architecture-handling approaches)"
+  },
+  {
+    "set_id": "455fa6995e0a",
+    "recipe_type": "download",
+    "app_name": "Dropbox",
+    "verdict": "recommend",
+    "confidence": "MEDIUM",
+    "keep": [
+      {
+        "repo": "MLBZ521-recipes",
+        "rel_path": "Dropbox/Dropbox-Universal.download.recipe.yaml",
+        "reason": "multi-arch support"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "recipes",
+        "rel_path": "Dropbox/Dropbox.download.recipe",
+        "reason": "no architecture variable"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "has architecture input variable for arm64/x64 selection"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "no architecture variable"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2023-10 vs 2013-08"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": "keep"
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "deprecate"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": "deprecate"
+      }
+    ],
+    "deprecation_message": "Consider switching to Dropbox recipes in the MLBZ521-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "3 child recipe(s) across 2 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "c019d6ff69d3",
+    "recipe_type": "download",
+    "app_name": "Dropbox Capture",
+    "verdict": "recommend",
+    "confidence": "MEDIUM",
+    "keep": [
+      {
+        "repo": "ahousseini-recipes",
+        "rel_path": "Dropbox Capture/Dropbox Capture.download.recipe",
+        "reason": "multi-arch support"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "joshua-d-miller-recipes",
+        "rel_path": "Dropbox/DropboxCapture.download.recipe",
+        "reason": "no architecture variable"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "has architecture input variable for arm64/x64 selection"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "no architecture variable"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2020-05 vs 2014-02"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": "keep"
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "deprecate"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to Dropbox Capture recipes in the ahousseini-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "2 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "736d8c457b45",
+    "recipe_type": "download",
+    "app_name": "EndNote",
+    "verdict": "skip",
+    "skip_reason": "different product versions (EndNote updates v19 vs EndNote X7 installer vs X7 updates)"
+  },
+  {
+    "set_id": "a256e769f0fd",
+    "recipe_type": "download",
+    "app_name": "erase-install",
+    "verdict": "recommend",
+    "confidence": "MEDIUM",
+    "keep": [
+      {
+        "repo": "grahampugh-recipes",
+        "rel_path": "erase-install/erase-install.download.recipe.yaml",
+        "reason": "recipe by erase-install author; uses official GitHub source; 3 dependents"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "scriptingosx-recipes",
+        "rel_path": "ProWarehouse/EraseInstall.download.recipe",
+        "reason": "uses Bitbucket source (erase-install moved to GitHub); has codesig but recipe by different author"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both download the erase-install tool"
+      },
+      {
+        "category": "favors_keep",
+        "text": "Recipe maintained by erase-install author (grahampugh); uses current GitHub source; 3 dependents across 3 repos"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "Uses old Bitbucket source (project moved to GitHub); has CodeSignatureVerifier but may check outdated signatures"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "grahampugh recipe is the authoritative source for this tool"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": "keep"
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": "keep"
+      }
+    ],
+    "deprecation_message": "Consider switching to erase-install recipes in the grahampugh-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "3 child recipe(s) across 3 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "16b0f37ebc00",
+    "recipe_type": "download",
+    "app_name": "ExpressVPN",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "dataJAR-recipes",
+        "rel_path": "ExpressVPN/ExpressVPN.download.recipe",
+        "reason": "established since 2018"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "moofit-recipes",
+        "rel_path": "ExpressVPN/ExpressVPN.download.recipe.yaml",
+        "reason": "newer duplicate (since 2022)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "2 dependent recipes"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2018-03 vs 2022-10"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": "keep"
+      }
+    ],
+    "deprecation_message": "Consider switching to ExpressVPN recipes in the dataJAR-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "5b9ff118c3a3",
+    "recipe_type": "download",
+    "app_name": "Fantastical",
+    "verdict": "recommend",
+    "confidence": "HIGH",
+    "keep": [
+      {
+        "repo": "macprince-recipes",
+        "rel_path": "Flexibits/Fantastical.download.recipe",
+        "reason": "has CodeSignatureVerifier; 3 dependents"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "jaharmi-recipes",
+        "rel_path": "Flexibits/Fantastical.download.recipe",
+        "reason": "missing CodeSignatureVerifier"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "has CodeSignatureVerifier; 3 dependent recipes"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "no CodeSignatureVerifier"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2017-03 vs 2013-09"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": "keep"
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "deprecate"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to Fantastical recipes in the macprince-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "2 child recipe(s) across 2 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "ca2d3854ba73",
+    "recipe_type": "download",
+    "app_name": "Fathom",
+    "verdict": "recommend",
+    "confidence": "MEDIUM",
+    "keep": [
+      {
+        "repo": "dataJAR-recipes",
+        "rel_path": "Fathom/Fathom.download.recipe",
+        "reason": "multi-arch support"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "joshua-d-miller-recipes",
+        "rel_path": "Fathom/Fathom.download.recipe",
+        "reason": "no architecture variable"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "has architecture input variable for arm64/x64 selection; 2 dependent recipes"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "no architecture variable"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2017-01 vs 2014-02"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": "keep"
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "deprecate"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to Fathom recipes in the dataJAR-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "99f00a413c3f",
+    "recipe_type": "download",
+    "app_name": "Fetch",
+    "verdict": "recommend",
+    "confidence": "MEDIUM",
+    "keep": [
+      {
+        "repo": "hansen-m-recipes",
+        "rel_path": "Fetch/Fetch.download.recipe",
+        "reason": "has CodeSignatureVerifier"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "jleggat-recipes",
+        "rel_path": "Fetch/Fetch.download.recipe",
+        "reason": "missing CodeSignatureVerifier"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "has CodeSignatureVerifier"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "no CodeSignatureVerifier"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2013-11 vs 2015-01"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": "keep"
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to Fetch recipes in the hansen-m-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "82b436f5f90b",
+    "recipe_type": "download",
+    "app_name": "Figma",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "dataJAR-recipes",
+        "rel_path": "Figma/Figma.download.recipe",
+        "reason": "4 dependents"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "smithjw-recipes",
+        "rel_path": "Figma/Figma-Universal.download.recipe.yaml",
+        "reason": "newer duplicate (since 2022)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "4 dependent recipes"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2018-05 vs 2022-09"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": "keep"
+      }
+    ],
+    "deprecation_message": "Consider switching to Figma recipes in the dataJAR-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "87f2b3819b96",
+    "recipe_type": "download",
+    "app_name": "Fission",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "homebysix-recipes",
+        "rel_path": "RogueAmoeba/Fission.download.recipe",
+        "reason": "3 dependents"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "andrewvalentine-recipes",
+        "rel_path": "Fission/Fission.download.recipe",
+        "reason": "newer duplicate (since 2022)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "3 dependent recipes"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2014-09 vs 2022-07"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to Fission recipes in the homebysix-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "c47c03a9a3c9",
+    "recipe_type": "download",
+    "app_name": "Fluid",
+    "verdict": "recommend",
+    "confidence": "HIGH",
+    "keep": [
+      {
+        "repo": "arubdesu-recipes",
+        "rel_path": "CelestialTeapotSoftware/Fluid.download.recipe",
+        "reason": "has CodeSignatureVerifier"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "jaharmi-recipes",
+        "rel_path": "CelestialTeapot/Fluid.download.recipe",
+        "reason": "missing CodeSignatureVerifier"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "has CodeSignatureVerifier; 2 dependent recipes"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "no CodeSignatureVerifier"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2014-03 vs 2013-09"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": "keep"
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "deprecate"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to Fluid recipes in the arubdesu-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "none",
+    "existing_prs": []
+  },
+  {
+    "set_id": "dbd15f1f7499",
+    "recipe_type": "download",
+    "app_name": "Flux",
+    "verdict": "recommend",
+    "confidence": "HIGH",
+    "keep": [
+      {
+        "repo": "keeleysam-recipes",
+        "rel_path": "Flux/Flux.download.recipe",
+        "reason": "has CodeSignatureVerifier; 5 dependents"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "jaharmi-recipes",
+        "rel_path": "Flux/Flux.download.recipe",
+        "reason": "missing CodeSignatureVerifier"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "has CodeSignatureVerifier; 5 dependent recipes"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "no CodeSignatureVerifier"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2013-08 vs 2013-09"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": "keep"
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to Flux recipes in the keeleysam-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "none",
+    "existing_prs": []
+  },
+  {
+    "set_id": "395651a0c2b0",
+    "recipe_type": "download",
+    "app_name": "FreeFileSync",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "bnpl-recipes",
+        "rel_path": "FreeFileSync/FreeFileSync.download.recipe",
+        "reason": "established since 2016"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "dataJAR-recipes",
+        "rel_path": "FreeFileSync/FreeFileSync.download.recipe",
+        "reason": "newer duplicate (since 2018)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2016-05 vs 2018-03"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to FreeFileSync recipes in the bnpl-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "cde4bd323805",
+    "recipe_type": "download",
+    "app_name": "GanttProject",
+    "verdict": "recommend",
+    "confidence": "HIGH",
+    "keep": [
+      {
+        "repo": "ahousseini-recipes",
+        "rel_path": "GanttProject/GanttProject.download.recipe",
+        "reason": "multi-arch support; has CodeSignatureVerifier"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "orchard-recipes",
+        "rel_path": "GanttProject/GanttProject.download.recipe",
+        "reason": "missing CodeSignatureVerifier; no architecture variable"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "has architecture input variable for arm64/x64 selection; has CodeSignatureVerifier; more resilient source (github vs unknown)"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "no CodeSignatureVerifier; no architecture variable; less resilient source (unknown)"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2020-05 vs 2015-10"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": "keep"
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": "keep"
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": "keep"
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "deprecate"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to GanttProject recipes in the ahousseini-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "2 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "1d87d0a8b50f",
+    "recipe_type": "download",
+    "app_name": "Glean",
+    "verdict": "skip",
+    "skip_reason": "different formats (PKG vs DMG from same vendor)"
+  },
+  {
+    "set_id": "a1f2e1f0f2aa",
+    "recipe_type": "download",
+    "app_name": "Go",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "timsutton-recipes",
+        "rel_path": "Go/Go.download.recipe",
+        "reason": "multi-arch support; 3 dependents"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "dataJAR-recipes",
+        "rel_path": "Go/Go.download.recipe",
+        "reason": "newer duplicate (since 2022)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "3 dependent recipes"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2013-11 vs 2022-05"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to Go recipes in the timsutton-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "08b28d7ce854",
+    "recipe_type": "download",
+    "app_name": "GoogleChrome",
+    "verdict": "skip",
+    "skip_reason": "different formats (DMG app bundle vs PKG installer from same vendor)"
+  },
+  {
+    "set_id": "1fa5059aa6b6",
+    "recipe_type": "download",
+    "app_name": "Handbrake",
+    "verdict": "recommend",
+    "confidence": "HIGH",
+    "keep": [
+      {
+        "repo": "recipes",
+        "rel_path": "Handbrake/Handbrake.download.recipe",
+        "reason": "has CodeSignatureVerifier; 4 dependents"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "keeleysam-recipes",
+        "rel_path": "Handbrake/Handbrake.download.recipe",
+        "reason": "missing CodeSignatureVerifier"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "has CodeSignatureVerifier; more resilient source (github vs sparkle); 4 dependent recipes"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "no CodeSignatureVerifier; less resilient source (sparkle)"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2013-08 vs 2013-09"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": "keep"
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": "keep"
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to Handbrake recipes in the recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "b8bf9e2f138e",
+    "recipe_type": "download",
+    "app_name": "Hudl Sportscode",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "primalcurve-recipes",
+        "rel_path": "Hudl/HudlSportscode.download.recipe",
+        "reason": "established since 2021"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "moofit-recipes",
+        "rel_path": "Hudl Sportscode/HudlSportscode.download.recipe.yaml",
+        "reason": "newer duplicate (since 2022)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2021-03 vs 2022-11"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": "keep"
+      }
+    ],
+    "deprecation_message": "Consider switching to Hudl Sportscode recipes in the primalcurve-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "523694e50fbc",
+    "recipe_type": "download",
+    "app_name": "IBM Notifier",
+    "verdict": "recommend",
+    "confidence": "HIGH",
+    "keep": [
+      {
+        "repo": "precursorca-recipes",
+        "rel_path": "IMB.Notifier/IBM.Notifier.download.recipe",
+        "reason": "uses official IBM/mac-ibm-notifications repo; has CodeSignatureVerifier; 4 dependents"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "moofit-recipes",
+        "rel_path": "IBM/IBMNotifier-custom.download.recipe.yaml",
+        "reason": "uses custom fork (moofit/ibm-notifier) with different icons; no CodeSignatureVerifier"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both download IBM Notifier from GitHub"
+      },
+      {
+        "category": "favors_keep",
+        "text": "Uses official IBM/mac-ibm-notifications repo; has CodeSignatureVerifier; 4 dependents across 4 repos"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "Uses custom fork with modified icons (moofit/ibm-notifier); no CodeSignatureVerifier; labeled as 'custom'"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": "keep"
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": "keep"
+      }
+    ],
+    "deprecation_message": "Consider switching to IBM Notifier recipes in the precursorca-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "none",
+    "existing_prs": []
+  },
+  {
+    "set_id": "bf11110af945",
+    "recipe_type": "download",
+    "app_name": "ImageJ",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "rtrouton-recipes",
+        "rel_path": "ImageJ/ImageJ.download.recipe",
+        "reason": "established since 2013"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "scriptingosx-recipes",
+        "rel_path": "ImageJ/ImageJ.download.recipe",
+        "reason": "newer duplicate (since 2014)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use EndOfCheckPhase"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2013-10 vs 2014-12"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": "deprecate"
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to ImageJ recipes in the rtrouton-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "94661fedd655",
+    "recipe_type": "download",
+    "app_name": "Insomnia",
+    "verdict": "recommend",
+    "confidence": "MEDIUM",
+    "keep": [
+      {
+        "repo": "dataJAR-recipes",
+        "rel_path": "Insomnia/Insomnia.download.recipe",
+        "reason": "established since 2018"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "gregneagle-recipes",
+        "rel_path": "FloatingKeyboardSoftware/Insomnia.download.recipe",
+        "reason": "functionally equivalent duplicate"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "more resilient source (github vs url)"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "less resilient source (url)"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2018-03 vs 2015-11"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": "keep"
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "deprecate"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to Insomnia recipes in the dataJAR-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "2 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "2cdfdfad6b67",
+    "recipe_type": "download",
+    "app_name": "iStopMotion",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "timsutton-recipes",
+        "rel_path": "Boinx/iStopMotion3.download.recipe",
+        "reason": "established since 2013"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "ahousseini-recipes",
+        "rel_path": "iStopMotion/iStopMotion.download.recipe",
+        "reason": "newer duplicate (since 2020)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2013-11 vs 2020-05"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to iStopMotion recipes in the timsutton-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "6a8a00c04f50",
+    "recipe_type": "download",
+    "app_name": "JetBrainsToolbox",
+    "verdict": "recommend",
+    "confidence": "HIGH",
+    "keep": [
+      {
+        "repo": "arubdesu-recipes",
+        "rel_path": "JetBrainsToolbox/JetBrainsToolbox.download.recipe",
+        "reason": "multi-arch support; 3 dependents"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "crystalllized-recipes",
+        "rel_path": "JetBrains Toolbox/JetBrainsToolbox.download.recipe",
+        "reason": "no architecture variable"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "has architecture input variable for arm64/x64 selection; more resilient source (url vs unknown); 3 dependent recipes"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "no architecture variable; less resilient source (unknown)"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2015-11 vs 2019-09"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": "keep"
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": "keep"
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to JetBrainsToolbox recipes in the arubdesu-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "a6b59292fbf0",
+    "recipe_type": "download",
+    "app_name": "Karabiner-Elements",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "apizz-recipes",
+        "rel_path": "Karabiner-Elements/Karabiner-Elements.download.recipe",
+        "reason": "established since 2018"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "Lotusshaney-recipes",
+        "rel_path": "Karabiner-Elements/Karabiner-Elements.download.recipe",
+        "reason": "newer duplicate (since 2022)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "more resilient source (github vs sparkle)"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "less resilient source (sparkle)"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2018-03 vs 2022-10"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": "keep"
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to Karabiner-Elements recipes in the apizz-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "2 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "1edb16973e77",
+    "recipe_type": "download",
+    "app_name": "KeeperPasswordManager",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "dataJAR-recipes",
+        "rel_path": "Keeper Password Manager/Keeper Password Manager.download.recipe",
+        "reason": "established since 2017"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "moofit-recipes",
+        "rel_path": "Keeper Security/KeeperPasswordManager.download.recipe.yaml",
+        "reason": "newer duplicate (since 2022)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2017-01 vs 2022-04"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": "keep"
+      }
+    ],
+    "deprecation_message": "Consider switching to KeeperPasswordManager recipes in the dataJAR-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "a4034f5c0f56",
+    "recipe_type": "download",
+    "app_name": "Keybase",
+    "verdict": "recommend",
+    "confidence": "MEDIUM",
+    "keep": [
+      {
+        "repo": "MLBZ521-recipes",
+        "rel_path": "Keybase/Keybase-Universal.download.recipe.yaml",
+        "reason": "multi-arch support"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "jaharmi-recipes",
+        "rel_path": "Keybase/Keybase.download.recipe",
+        "reason": "no architecture variable"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "has architecture input variable for arm64/x64 selection"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "no architecture variable"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2023-10 vs 2017-02"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": "keep"
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "deprecate"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": "deprecate"
+      }
+    ],
+    "deprecation_message": "Consider switching to Keybase recipes in the MLBZ521-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "4 child recipe(s) across 4 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "8a3aad74485f",
+    "recipe_type": "download",
+    "app_name": "Kite Student Portal",
+    "verdict": "skip",
+    "skip_reason": "different formats (DMG vs PKG from same vendor)"
+  },
+  {
+    "set_id": "0c709f3326c1",
+    "recipe_type": "download",
+    "app_name": "Knock",
+    "verdict": "recommend",
+    "confidence": "MEDIUM",
+    "keep": [
+      {
+        "repo": "homebysix-recipes",
+        "rel_path": "Knock/Knock.download.recipe",
+        "reason": "has CodeSignatureVerifier; 3 dependents"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "jaharmi-recipes",
+        "rel_path": "Knock/Knock.download.recipe",
+        "reason": "missing CodeSignatureVerifier"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "has CodeSignatureVerifier; 3 dependent recipes"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "no CodeSignatureVerifier"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2015-08 vs 2013-09"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": "keep"
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "deprecate"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to Knock recipes in the homebysix-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "295940dc7d3b",
+    "recipe_type": "download",
+    "app_name": "KnockKnock",
+    "verdict": "recommend",
+    "confidence": "MEDIUM",
+    "keep": [
+      {
+        "repo": "andrewvalentine-recipes",
+        "rel_path": "KnockKnock/KnockKnock.download.recipe",
+        "reason": "established since 2016"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "dataJAR-recipes",
+        "rel_path": "KnockKnock/KnockKnock.download.recipe",
+        "reason": "newer duplicate (since 2018)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "more resilient source (github vs url)"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "less resilient source (url)"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2016-01 vs 2018-03"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": "keep"
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to KnockKnock recipes in the andrewvalentine-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "2 child recipe(s) across 2 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "24d62dc5c358",
+    "recipe_type": "download",
+    "app_name": "kubectl",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "homebysix-recipes",
+        "rel_path": "Kubernetes/kubectl.download.recipe",
+        "reason": "established since 2014"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "nstrauss-recipes",
+        "rel_path": "kubectl/kubectl.download.recipe",
+        "reason": "newer duplicate (since 2023)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use EndOfCheckPhase"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2014-09 vs 2023-01"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": "deprecate"
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to kubectl recipes in the homebysix-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "704ae6bf291a",
+    "recipe_type": "download",
+    "app_name": "LanguageTool for Desktop",
+    "verdict": "recommend",
+    "confidence": "MEDIUM",
+    "keep": [
+      {
+        "repo": "andredb90-recipes",
+        "rel_path": "LanguageTool for Desktop/LanguageToolforDesktop.download.recipe",
+        "reason": "established since 2019"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "zentral-recipes",
+        "rel_path": "LanguageTool/LanguageToolDesktop.download.recipe",
+        "reason": "functionally equivalent duplicate"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "more resilient source (sparkle vs url)"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "less resilient source (url)"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2019-08 vs 2018-07"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": "keep"
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "deprecate"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to LanguageTool for Desktop recipes in the andredb90-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "a46a25cff2f5",
+    "recipe_type": "download",
+    "app_name": "LaunchBar",
+    "verdict": "recommend",
+    "confidence": "HIGH",
+    "keep": [
+      {
+        "repo": "homebysix-recipes",
+        "rel_path": "ObjectiveDevelopment/LaunchBar.download.recipe",
+        "reason": "has CodeSignatureVerifier; 4 dependents"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "jaharmi-recipes",
+        "rel_path": "ObjectiveDevelopment/LaunchBar5.download.recipe",
+        "reason": "missing CodeSignatureVerifier"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "has CodeSignatureVerifier; more resilient source (url vs unknown); 4 dependent recipes"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "no CodeSignatureVerifier; less resilient source (unknown)"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2014-09 vs 2013-09"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": "keep"
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": "keep"
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "deprecate"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to LaunchBar recipes in the homebysix-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "226ab6c45315",
+    "recipe_type": "download",
+    "app_name": "Lens",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "dataJAR-recipes",
+        "rel_path": "Lens/Lens.download.recipe",
+        "reason": "multi-arch support"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "ahousseini-recipes",
+        "rel_path": "Lens/Lens.download.recipe",
+        "reason": "newer duplicate (since 2020)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2018-03 vs 2020-05"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to Lens recipes in the dataJAR-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "2 child recipe(s) across 2 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "b925e75d946f",
+    "recipe_type": "download",
+    "app_name": "LoggerPro",
+    "verdict": "skip",
+    "skip_reason": "different products (Logger Pro application update vs Logger Pro license file)"
+  },
+  {
+    "set_id": "2ddbd58f13b8",
+    "recipe_type": "download",
+    "app_name": "Logitech Control Center",
+    "verdict": "skip",
+    "skip_reason": "different products (Logitech Control Center vs Logitech Camera Settings)"
+  },
+  {
+    "set_id": "94691be0d35c",
+    "recipe_type": "download",
+    "app_name": "LuLu",
+    "verdict": "recommend",
+    "confidence": "MEDIUM",
+    "keep": [
+      {
+        "repo": "apettinen-recipes",
+        "rel_path": "LuLu/LuLu.download.recipe",
+        "reason": "established since 2017"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "dataJAR-recipes",
+        "rel_path": "LuLu/LuLu.download.recipe",
+        "reason": "functionally equivalent duplicate"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "more resilient source (github vs url)"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "less resilient source (url)"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2017-09 vs 2017-02"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": "keep"
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "deprecate"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to LuLu recipes in the apettinen-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "2 child recipe(s) across 2 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "756adf31b715",
+    "recipe_type": "download",
+    "app_name": "LyX",
+    "verdict": "recommend",
+    "confidence": "MEDIUM",
+    "keep": [
+      {
+        "repo": "joshua-d-miller-recipes",
+        "rel_path": "LyX/lyx.download.recipe",
+        "reason": "established since 2014"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "ahousseini-recipes",
+        "rel_path": "LyX/LyX.download.recipe",
+        "reason": "newer duplicate (since 2020)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "more resilient source (url vs unknown)"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "less resilient source (unknown)"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2014-02 vs 2020-05"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": "keep"
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to LyX recipes in the joshua-d-miller-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "85f377e747cf",
+    "recipe_type": "download",
+    "app_name": "Malwarebytes",
+    "verdict": "skip",
+    "skip_reason": "different products (Malwarebytes consumer vs Malwarebytes Incident Response enterprise tool)"
+  },
+  {
+    "set_id": "7858eb674089",
+    "recipe_type": "download",
+    "app_name": "Marked2",
+    "verdict": "recommend",
+    "confidence": "MEDIUM",
+    "keep": [
+      {
+        "repo": "homebysix-recipes",
+        "rel_path": "Marked/Marked2.download.recipe",
+        "reason": "has CodeSignatureVerifier; 3 dependents"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "jaharmi-recipes",
+        "rel_path": "Terpstra/Marked2.download.recipe",
+        "reason": "missing CodeSignatureVerifier"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "has CodeSignatureVerifier; 3 dependent recipes"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "no CodeSignatureVerifier"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2015-08 vs 2013-09"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": "keep"
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "deprecate"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to Marked2 recipes in the homebysix-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "none",
+    "existing_prs": []
+  },
+  {
+    "set_id": "ab1ca5bdf7ef",
+    "recipe_type": "download",
+    "app_name": "mBlock",
+    "verdict": "recommend",
+    "confidence": "MEDIUM",
+    "keep": [
+      {
+        "repo": "ahousseini-recipes",
+        "rel_path": "mBlock/mBlock.download.recipe",
+        "reason": "multi-arch support"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "joshua-d-miller-recipes",
+        "rel_path": "makeblock/mBlock.download.recipe",
+        "reason": "no architecture variable"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "has architecture input variable for arm64/x64 selection"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "no architecture variable"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2020-05 vs 2019-07"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": "keep"
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "deprecate"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to mBlock recipes in the ahousseini-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "f3206dec7452",
+    "recipe_type": "download",
+    "app_name": "Mendeley Reference Manager",
+    "verdict": "recommend",
+    "confidence": "MEDIUM",
+    "keep": [
+      {
+        "repo": "grahampugh-recipes",
+        "rel_path": "MendeleyReferenceManager/MendeleyReferenceManager.download.recipe.yaml",
+        "reason": "established since 2021"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "joshua-d-miller-recipes",
+        "rel_path": "Mendeley/MendeleyReferenceManager.download.recipe",
+        "reason": "functionally equivalent duplicate"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier"
+      },
+      {
+        "category": "favors_keep",
+        "text": "has EndOfCheckPhase"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "no EndOfCheckPhase"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2021-08 vs 2019-07"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": "keep"
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "deprecate"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": "deprecate"
+      }
+    ],
+    "deprecation_message": "Consider switching to Mendeley Reference Manager recipes in the grahampugh-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "990ebe124263",
+    "recipe_type": "download",
+    "app_name": "Menu Bar Spacing",
+    "verdict": "recommend",
+    "confidence": "MEDIUM",
+    "keep": [
+      {
+        "repo": "homebysix-recipes",
+        "rel_path": "MenuBarSpacing/MenuBarSpacing.download.recipe",
+        "reason": "established since 2015"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "almenscorner-recipes",
+        "rel_path": "Sindre Sorhus/MenuBarSpacing.download.recipe",
+        "reason": "newer duplicate (since 2025)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "more resilient source (sparkle vs url); 2 dependent recipes"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "less resilient source (url)"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2015-08 vs 2025-03"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": "keep"
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to Menu Bar Spacing recipes in the homebysix-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "c42da125040c",
+    "recipe_type": "download",
+    "app_name": "MenuMeters",
+    "verdict": "recommend",
+    "confidence": "HIGH",
+    "keep": [
+      {
+        "repo": "kevinmcox-recipes",
+        "rel_path": "Yuji Tachikawa/MenuMeters.download.recipe",
+        "reason": "has CodeSignatureVerifier; 4 dependents"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "jleggat-recipes",
+        "rel_path": "RagingMenace/MenuMeters.download.recipe",
+        "reason": "missing CodeSignatureVerifier"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "has CodeSignatureVerifier; more resilient source (sparkle vs url); 4 dependent recipes"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "no CodeSignatureVerifier; less resilient source (url)"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2020-01 vs 2013-10"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": "keep"
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": "keep"
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "deprecate"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to MenuMeters recipes in the kevinmcox-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "6205742f771f",
+    "recipe_type": "download",
+    "app_name": "MestReNova",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "vmiller-recipes",
+        "rel_path": "Mestrelab Research/MestReNova.download.recipe",
+        "reason": "established since 2015"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "andrewvalentine-recipes",
+        "rel_path": "MestReNova/MestReNova.download.recipe",
+        "reason": "newer duplicate (since 2016)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2015-03 vs 2016-01"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to MestReNova recipes in the vmiller-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "2 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "c21fc40cd6ea",
+    "recipe_type": "download",
+    "app_name": "Microsoft Office 365 Suite",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "rtrouton-recipes",
+        "rel_path": "MicrosoftOffice365Suite/MicrosoftOffice365Suite.download.recipe",
+        "reason": "4 dependents"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "novaksam-recipes",
+        "rel_path": "Recipes - Download/MicrosoftOffice365Suite.download.recipe",
+        "reason": "newer duplicate (since 2019)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "4 dependent recipes"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2017-09 vs 2019-05"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to Microsoft Office 365 Suite recipes in the rtrouton-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "45fa5acd5068",
+    "recipe_type": "download",
+    "app_name": "Mountain Duck",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "rtrouton-recipes",
+        "rel_path": "MountainDuck/MountainDuck.download.recipe",
+        "reason": "3 dependents"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "ahousseini-recipes",
+        "rel_path": "MountainDuck/MountainDuck.download.recipe",
+        "reason": "newer duplicate (since 2020)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "3 dependent recipes"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2016-01 vs 2020-05"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": "deprecate"
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to Mountain Duck recipes in the rtrouton-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "bf22efed0cd6",
+    "recipe_type": "download",
+    "app_name": "mtr",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "peshay-recipes",
+        "rel_path": "MTR/MTR.download.recipe",
+        "reason": "established since 2016"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "orchard-recipes",
+        "rel_path": "mtr/mtr.download.recipe",
+        "reason": "functionally equivalent duplicate"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "more resilient source (url vs None)"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "less resilient source (None)"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2016-09 vs 2015-11"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": "deprecate"
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": "keep"
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "deprecate"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to mtr recipes in the peshay-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "3270a6dedc84",
+    "recipe_type": "download",
+    "app_name": "MunkiAdmin",
+    "verdict": "skip",
+    "skip_reason": "different products (MunkiAdmin for munki management vs Protege ontology editor)"
+  },
+  {
+    "set_id": "e602424eb9ec",
+    "recipe_type": "download",
+    "app_name": "MuseScore4",
+    "verdict": "recommend",
+    "confidence": "MEDIUM",
+    "keep": [
+      {
+        "repo": "dataJAR-recipes",
+        "rel_path": "MuseScore 4/MuseScore 4.download.recipe",
+        "reason": "established since 2017"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "jazzace-recipes",
+        "rel_path": "MuseScore/MuseScore.download.recipe",
+        "reason": "functionally equivalent duplicate"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "more resilient source (github vs url)"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "less resilient source (url)"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2017-01 vs 2014-09"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": "keep"
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "deprecate"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to MuseScore4 recipes in the dataJAR-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "3 child recipe(s) across 3 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "03b1fe3fed35",
+    "recipe_type": "download",
+    "app_name": "MySQL Workbench",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "homebysix-recipes",
+        "rel_path": "MySQLWorkbench/MySQLWorkbench.download.recipe",
+        "reason": "multi-arch support; 4 dependents"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "MLBZ521-recipes",
+        "rel_path": "MySQL/MySQLWorkbench-Universal.download.recipe.yaml",
+        "reason": "newer duplicate (since 2022)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "4 dependent recipes"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2014-09 vs 2022-11"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": "keep"
+      }
+    ],
+    "deprecation_message": "Consider switching to MySQL Workbench recipes in the homebysix-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "5191dd28f8a2",
+    "recipe_type": "download",
+    "app_name": "Nessus Agent",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "neilmartin83-recipes",
+        "rel_path": "Tenable/Nessus Agent.download.recipe.yaml",
+        "reason": "established since 2025"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "skoobasteeve-recipes",
+        "rel_path": "Nessus Agent/Nessus Agent.download.recipe",
+        "reason": "functionally equivalent duplicate"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "2 dependent recipes"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2025-01 vs 2021-12"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "deprecate"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": "deprecate"
+      }
+    ],
+    "deprecation_message": "Consider switching to Nessus Agent recipes in the neilmartin83-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "none",
+    "existing_prs": []
+  },
+  {
+    "set_id": "518eb77b7751",
+    "recipe_type": "download",
+    "app_name": "NordPass",
+    "verdict": "recommend",
+    "confidence": "MEDIUM",
+    "keep": [
+      {
+        "repo": "dataJAR-recipes",
+        "rel_path": "NordPass/NordPass.download.recipe",
+        "reason": "multi-arch support"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "jamestpotts-recipes",
+        "rel_path": "NordPass/NordPass_Universal.download.recipe.yaml",
+        "reason": "no architecture variable"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "has architecture input variable for arm64/x64 selection"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "no architecture variable"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2017-01 vs 2025-09"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": "keep"
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": "keep"
+      }
+    ],
+    "deprecation_message": "Consider switching to NordPass recipes in the dataJAR-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "44e3050f0891",
+    "recipe_type": "download",
+    "app_name": "Notion",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "swy-recipes",
+        "rel_path": "Notion Labs, Inc./Notion.download.recipe",
+        "reason": "3 dependents"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "moofit-recipes",
+        "rel_path": "Notion Labs/NotionUniversal.download.recipe.yaml",
+        "reason": "newer duplicate (since 2022)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "3 dependent recipes"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2017-06 vs 2022-01"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": "keep"
+      }
+    ],
+    "deprecation_message": "Consider switching to Notion recipes in the swy-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "2 child recipe(s) across 2 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "6e49231153c2",
+    "recipe_type": "download",
+    "app_name": "OBS",
+    "verdict": "recommend",
+    "confidence": "MEDIUM",
+    "keep": [
+      {
+        "repo": "nstrauss-recipes",
+        "rel_path": "OBS/OBS.download.recipe",
+        "reason": "multi-arch support"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "ahousseini-recipes",
+        "rel_path": "OBS/OBS.download.recipe",
+        "reason": "newer duplicate (since 2020)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "more resilient source (url vs unknown); 2 dependent recipes"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "less resilient source (unknown)"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2017-01 vs 2020-05"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": "keep"
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to OBS recipes in the nstrauss-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "df017bc01c4a",
+    "recipe_type": "download",
+    "app_name": "OverSight",
+    "verdict": "recommend",
+    "confidence": "MEDIUM",
+    "keep": [
+      {
+        "repo": "oliverweinm-recipes",
+        "rel_path": "Objective-See/OverSight.download.recipe",
+        "reason": "established since 2022"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "dataJAR-recipes",
+        "rel_path": "OverSight/OverSight.download.recipe",
+        "reason": "functionally equivalent duplicate"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "more resilient source (github vs url)"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "less resilient source (url)"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2022-05 vs 2018-03"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": "keep"
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "deprecate"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to OverSight recipes in the oliverweinm-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "42e40e04154a",
+    "recipe_type": "download",
+    "app_name": "Papers",
+    "verdict": "skip",
+    "skip_reason": "different products (Papers 5 vs Papers 2 from different sources)"
+  },
+  {
+    "set_id": "ec9fecc6ead2",
+    "recipe_type": "download",
+    "app_name": "Pd",
+    "verdict": "recommend",
+    "confidence": "MEDIUM",
+    "keep": [
+      {
+        "repo": "orbsmiv-recipes",
+        "rel_path": "Pd/Pd.download.recipe",
+        "reason": "has CodeSignatureVerifier"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "paul-cossey-recipes",
+        "rel_path": "Pd/Pd.download.recipe",
+        "reason": "missing CodeSignatureVerifier"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "has CodeSignatureVerifier"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "no CodeSignatureVerifier"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2016-10 vs 2021-01"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": "keep"
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to Pd recipes in the orbsmiv-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "3 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "71d7484a3589",
+    "recipe_type": "download",
+    "app_name": "Pencil",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "hansen-m-recipes",
+        "rel_path": "Pencil/Pencil.download.recipe",
+        "reason": "established since 2013"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "dataJAR-recipes",
+        "rel_path": "Pencil/Pencil.download.recipe",
+        "reason": "newer duplicate (since 2018)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use EndOfCheckPhase"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2013-11 vs 2018-03"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": "deprecate"
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to Pencil recipes in the hansen-m-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "944e537912cf",
+    "recipe_type": "download",
+    "app_name": "PhotoMechanic",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "eholtam-recipes",
+        "rel_path": "PhotoMechanic/PhotoMechanic.download.recipe",
+        "reason": "release channel variable"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "kevinmcox-recipes",
+        "rel_path": "Camera Bits, Inc./PhotoMechanic.download.recipe",
+        "reason": "no release variable"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "has release channel input variable"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "no release variable"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2016-04 vs 2020-01"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": "keep"
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to PhotoMechanic recipes in the eholtam-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "3 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "34a79e826628",
+    "recipe_type": "download",
+    "app_name": "PodmanDesktop",
+    "verdict": "recommend",
+    "confidence": "HIGH",
+    "keep": [
+      {
+        "repo": "apettinen-recipes",
+        "rel_path": "Podman/PodmanDesktop.download.recipe",
+        "reason": "uses current podman-desktop/podman-desktop repo with arch/format variables"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "gregneagle-recipes",
+        "rel_path": "Podman/PodmanDesktop.download.recipe",
+        "reason": "uses containers/podman-desktop (old repo path); uses raw API URL instead of GitHubReleasesInfoProvider"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "has architecture input variable for arm64/x64 selection; more resilient source (github vs url)"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "no architecture variable; less resilient source (url)"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2024-11 vs 2022-11"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": "keep"
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": "keep"
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "deprecate"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to PodmanDesktop recipes in the apettinen-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "4 child recipe(s) across 2 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "a4974ac4aeb7",
+    "recipe_type": "download",
+    "app_name": "PollEverywhere",
+    "verdict": "recommend",
+    "confidence": "MEDIUM",
+    "keep": [
+      {
+        "repo": "dataJAR-recipes",
+        "rel_path": "Poll Everywhere/Poll Everywhere.download.recipe",
+        "reason": "established since 2017"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "haircut-recipes",
+        "rel_path": "PollEverywhere/PollEverywhereApp.download.recipe",
+        "reason": "newer duplicate (since 2018)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "more resilient source (sparkle vs url)"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "less resilient source (url)"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2017-01 vs 2018-05"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": "keep"
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to PollEverywhere recipes in the dataJAR-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "5ef7a29cb54f",
+    "recipe_type": "download",
+    "app_name": "Postman",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "dataJAR-recipes",
+        "rel_path": "Postman/Postman.download.recipe",
+        "reason": "multi-arch support; 4 dependents"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "n8felton-recipes",
+        "rel_path": "Postman/Postman.download.recipe",
+        "reason": "functionally equivalent duplicate"
+      },
+      {
+        "repo": "bnpl-recipes",
+        "rel_path": "Postman/Postman.download.recipe",
+        "reason": "no architecture variable"
+      },
+      {
+        "repo": "smithjw-recipes",
+        "rel_path": "Postman/Postman-Universal.download.recipe.yaml",
+        "reason": "no architecture variable"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "has architecture input variable for arm64/x64 selection; more resilient source (url vs unknown); 4 dependent recipes"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "less resilient source (unknown)"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "no architecture variable"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "no architecture variable"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2019-04 vs 2016-10"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2019-04 vs 2016-05"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2019-04 vs 2022-09"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": "keep"
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": "deprecate"
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": "keep"
+      }
+    ],
+    "deprecation_message": "Consider switching to Postman recipes in the dataJAR-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "3 child recipe(s) across 3 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "df50c1e28024",
+    "recipe_type": "download",
+    "app_name": "PrismaAccessBrowser",
+    "verdict": "skip",
+    "skip_reason": "different formats (app bundle via Sparkle vs PKG installer via packaged channel)"
+  },
+  {
+    "set_id": "e6ba83304e65",
+    "recipe_type": "download",
+    "app_name": "PritunlClient",
+    "verdict": "recommend",
+    "confidence": "MEDIUM",
+    "keep": [
+      {
+        "repo": "dataJAR-recipes",
+        "rel_path": "Pritunl Client/PritunlClient.download.recipe",
+        "reason": "uses current pritunl/pritunl-client-electron repo; supports prereleases"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "Tecnico1931-recipes",
+        "rel_path": "PritunlClient/PritunlClient.download.recipe",
+        "reason": "uses older pritunl/pritunlclient repo"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "3 dependent recipes"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2016-12 vs 2017-01"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to PritunlClient recipes in the dataJAR-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "06b3da3ba646",
+    "recipe_type": "download",
+    "app_name": "ProtonVPN",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "dataJAR-recipes",
+        "rel_path": "ProtonVPN/ProtonVPN.download.recipe",
+        "reason": "3 dependents"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "moofit-recipes",
+        "rel_path": "ProtonVPN/ProtonVPN.download.recipe.yaml",
+        "reason": "newer duplicate (since 2024)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "3 dependent recipes"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2017-01 vs 2024-04"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": "keep"
+      }
+    ],
+    "deprecation_message": "Consider switching to ProtonVPN recipes in the dataJAR-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "62661e06fec8",
+    "recipe_type": "download",
+    "app_name": "Proxyman",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "zentral-recipes",
+        "rel_path": "Proxyman/Proxyman.download.recipe",
+        "reason": "3 dependents"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "Lotusshaney-recipes",
+        "rel_path": "Proxyman/Proxyman.download.recipe",
+        "reason": "newer duplicate (since 2025)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "3 dependent recipes"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2018-07 vs 2025-04"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to Proxyman recipes in the zentral-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "2 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "96fe5acf4708",
+    "recipe_type": "download",
+    "app_name": "QLab5",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "dataJAR-recipes",
+        "rel_path": "QLab5/QLab5.download.recipe",
+        "reason": "established since 2017"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "moofit-recipes",
+        "rel_path": "QLab 5/Qlab5.download.recipe.yaml",
+        "reason": "newer duplicate (since 2023)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "2 dependent recipes"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2017-01 vs 2023-06"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": "keep"
+      }
+    ],
+    "deprecation_message": "Consider switching to QLab5 recipes in the dataJAR-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "a17f098e19e8",
+    "recipe_type": "download",
+    "app_name": "QuickBooks",
+    "verdict": "skip",
+    "skip_reason": "different product versions (current QuickBooks vs QuickBooks 2016)"
+  },
+  {
+    "set_id": "a7a1b23a1c87",
+    "recipe_type": "download",
+    "app_name": "Read&Write",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "haircut-recipes",
+        "rel_path": "texthelp/ReadWrite7.download.recipe",
+        "reason": "3 dependents"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "moofit-recipes",
+        "rel_path": "TextHelp/ReadWrite.download.recipe.yaml",
+        "reason": "newer duplicate (since 2023)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "3 dependent recipes"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2018-05 vs 2023-06"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": "keep"
+      }
+    ],
+    "deprecation_message": "Consider switching to Read&Write recipes in the haircut-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "d4321976222a",
+    "recipe_type": "download",
+    "app_name": "Rectangle",
+    "verdict": "recommend",
+    "confidence": "MEDIUM",
+    "keep": [
+      {
+        "repo": "dataJAR-recipes",
+        "rel_path": "Rectangle/Rectangle.download.recipe",
+        "reason": "4 dependents"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "peetinc-recipes",
+        "rel_path": "Rectangle/Rectangle.download.recipe",
+        "reason": "newer duplicate (since 2019)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "more resilient source (github vs sparkle); 4 dependent recipes"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "less resilient source (sparkle)"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2017-01 vs 2019-11"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": "keep"
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to Rectangle recipes in the dataJAR-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "2 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "f89594872a4c",
+    "recipe_type": "download",
+    "app_name": "ReiKey",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "dataJAR-recipes",
+        "rel_path": "ReiKey/ReiKey.download.recipe",
+        "reason": "established since 2018"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "peshay-recipes",
+        "rel_path": "Objective-See/ReiKey.download.recipe",
+        "reason": "newer duplicate (since 2019)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2018-03 vs 2019-01"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to ReiKey recipes in the dataJAR-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "2 child recipe(s) across 2 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "5ce910bbe42a",
+    "recipe_type": "download",
+    "app_name": "RingCentral",
+    "verdict": "skip",
+    "skip_reason": "different architectures (universal PKG vs arm64-specific PKG)"
+  },
+  {
+    "set_id": "cdb039b9f80a",
+    "recipe_type": "download",
+    "app_name": "RODE Connect",
+    "verdict": "skip",
+    "skip_reason": "different products (RODE Connect audio mixing vs RODE Central device management)"
+  },
+  {
+    "set_id": "57c1381a1f46",
+    "recipe_type": "download",
+    "app_name": "SafeExamBrowser",
+    "verdict": "recommend",
+    "confidence": "MEDIUM",
+    "keep": [
+      {
+        "repo": "apizz-recipes",
+        "rel_path": "Safe Exam Browser/SEB-Github.download.recipe",
+        "reason": "has CodeSignatureVerifier"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "ahousseini-recipes",
+        "rel_path": "SafeExamBrowser/SafeExamBrowser.download.recipe",
+        "reason": "newer duplicate (since 2020)"
+      },
+      {
+        "repo": "aanklewicz-recipes",
+        "rel_path": "Safe Exam Browser/SEB.download.recipe",
+        "reason": "missing CodeSignatureVerifier"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "has CodeSignatureVerifier; more resilient source (github vs url)"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "less resilient source (url)"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "no CodeSignatureVerifier; less resilient source (unknown)"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2018-03 vs 2020-05"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2018-03 vs 2015-01"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": "keep"
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": "keep"
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "deprecate"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to SafeExamBrowser recipes in the apizz-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "3 child recipe(s) across 2 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "94a3dff6c3a8",
+    "recipe_type": "download",
+    "app_name": "Scratch 3",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "dataJAR-recipes",
+        "rel_path": "Scratch 3/Scratch 3.download.recipe",
+        "reason": "3 dependents"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "nstrauss-recipes",
+        "rel_path": "Scratch 3/Scratch3.download.recipe",
+        "reason": "functionally equivalent duplicate"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "3 dependent recipes"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2019-01 vs 2017-01"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "deprecate"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to Scratch 3 recipes in the dataJAR-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "56e01fe55dd1",
+    "recipe_type": "download",
+    "app_name": "ScreenFlow",
+    "verdict": "recommend",
+    "confidence": "MEDIUM",
+    "keep": [
+      {
+        "repo": "rderewianko-recipes",
+        "rel_path": "ScreenFlow/ScreenFlow.download.recipe",
+        "reason": "4 dependents"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "peshay-recipes",
+        "rel_path": "ScreenFlow/ScreenFlow.download.recipe",
+        "reason": "newer duplicate (since 2016)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase, url source (www.telestream.net/updater/screenflow/appcast.xml)"
+      },
+      {
+        "category": "favors_keep",
+        "text": "more resilient source (sparkle vs url); 4 dependent recipes"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "less resilient source (url)"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2016-03 vs 2016-09"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to ScreenFlow recipes in the rderewianko-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "2 child recipe(s) across 2 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "5712451cc297",
+    "recipe_type": "download",
+    "app_name": "Sejda PDF Desktop",
+    "verdict": "recommend",
+    "confidence": "HIGH",
+    "keep": [
+      {
+        "repo": "homebysix-recipes",
+        "rel_path": "SejdaPDFDesktop/SejdaPDFDesktop.download.recipe",
+        "reason": "multi-arch support"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "ahousseini-recipes",
+        "rel_path": "Sejda PDF Desktop/Sejda PDF Desktop.download.recipe",
+        "reason": "no architecture variable"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "has architecture input variable for arm64/x64 selection; more resilient source (url vs unknown)"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "no architecture variable; less resilient source (unknown)"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2015-08 vs 2020-05"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": "keep"
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": "keep"
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to Sejda PDF Desktop recipes in the homebysix-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "2 child recipe(s) across 2 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "3c6fe1d42962",
+    "recipe_type": "download",
+    "app_name": "Shadow",
+    "verdict": "skip",
+    "skip_reason": "different products (Shadow cloud gaming PC streaming vs Shadow motion capture)"
+  },
+  {
+    "set_id": "03a24987b36a",
+    "recipe_type": "download",
+    "app_name": "SigniantApp",
+    "verdict": "recommend",
+    "confidence": "MEDIUM",
+    "keep": [
+      {
+        "repo": "dataJAR-recipes",
+        "rel_path": "Signiant App/Signiant App.download.recipe",
+        "reason": "established since 2017"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "brianwells-recipes",
+        "rel_path": "Signiant/SigniantApp.download.recipe",
+        "reason": "functionally equivalent duplicate"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "more resilient source (url vs unknown)"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "less resilient source (unknown)"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2017-01 vs 2016-12"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": "keep"
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "deprecate"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to SigniantApp recipes in the dataJAR-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "b1918d094b5a",
+    "recipe_type": "download",
+    "app_name": "SketchUp Pro 2023 EN",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "dataJAR-recipes",
+        "rel_path": "SketchUp Pro 2023 EN/SketchUp Pro 2023 EN.download.recipe",
+        "reason": "established since 2017"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "moofit-recipes",
+        "rel_path": "SketchUp Pro 2023/SketchUpPro2023.download.recipe.yaml",
+        "reason": "newer duplicate (since 2023)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2017-06 vs 2023-06"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": "keep"
+      }
+    ],
+    "deprecation_message": "Consider switching to SketchUp Pro 2023 EN recipes in the dataJAR-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "bb47b19b7912",
+    "recipe_type": "download",
+    "app_name": "Slack",
+    "verdict": "skip",
+    "skip_reason": "different formats and architectures (DMG vs PKG, Intel vs Apple Silicon vs Universal)"
+  },
+  {
+    "set_id": "ae4a1f3425b5",
+    "recipe_type": "download",
+    "app_name": "Sloth",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "andrewvalentine-recipes",
+        "rel_path": "Sloth/Sloth.download.recipe",
+        "reason": "established since 2016"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "precursorca-recipes",
+        "rel_path": "Sloth/Sloth.download.recipe",
+        "reason": "newer duplicate (since 2017)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "more resilient source (github vs sparkle)"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "less resilient source (sparkle)"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2016-01 vs 2017-10"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": "keep"
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to Sloth recipes in the andrewvalentine-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "3 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "b5cbaf7ea8f7",
+    "recipe_type": "download",
+    "app_name": "SQLProforPostgres",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "apizz-recipes",
+        "rel_path": "SQLPro_for_Postgres/SQLProforPostgres.download.recipe",
+        "reason": "established since 2018"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "Lotusshaney-recipes",
+        "rel_path": "SQLPro for Postgres/SQLPro for Postgres.download.recipe",
+        "reason": "newer duplicate (since 2022)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2018-03 vs 2022-10"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to SQLProforPostgres recipes in the apizz-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "d4f7a5ebcc4d",
+    "recipe_type": "download",
+    "app_name": "swiftDialog",
+    "verdict": "recommend",
+    "confidence": "HIGH",
+    "keep": [
+      {
+        "repo": "zentral-recipes",
+        "rel_path": "swiftDialog/swiftDialog.download.recipe",
+        "reason": "has CodeSignatureVerifier; 11 dependents"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "moofit-recipes",
+        "rel_path": "swiftDialog/swiftDialog-local.download.recipe.yaml",
+        "reason": "missing CodeSignatureVerifier"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "favors_keep",
+        "text": "has CodeSignatureVerifier; has EndOfCheckPhase; more resilient source (github vs None); 11 dependent recipes"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "no CodeSignatureVerifier; no EndOfCheckPhase; less resilient source (None)"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2020-12 vs 2024-12"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": "keep"
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": "keep"
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": "keep"
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": "keep"
+      }
+    ],
+    "deprecation_message": "Consider switching to swiftDialog recipes in the zentral-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "d1935d81f37f",
+    "recipe_type": "download",
+    "app_name": "TableauPublic",
+    "verdict": "recommend",
+    "confidence": "MEDIUM",
+    "keep": [
+      {
+        "repo": "MLBZ521-recipes",
+        "rel_path": "Tableau/TableauPublic-Universal.download.recipe.yaml",
+        "reason": "multi-arch support"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "foigus-recipes",
+        "rel_path": "Tableau/TableauPublic.download.recipe",
+        "reason": "no architecture variable"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "has architecture input variable for arm64/x64 selection"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "no architecture variable"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2024-09 vs 2015-06"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": "keep"
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "deprecate"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": "deprecate"
+      }
+    ],
+    "deprecation_message": "Consider switching to TableauPublic recipes in the MLBZ521-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "3 child recipe(s) across 3 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "4df48ca87c88",
+    "recipe_type": "download",
+    "app_name": "TeamViewerQS",
+    "verdict": "recommend",
+    "confidence": "MEDIUM",
+    "keep": [
+      {
+        "repo": "hjuutilainen-recipes",
+        "rel_path": "TeamViewer/TeamViewerQuickSupport.download.recipe",
+        "reason": "6 dependents"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "moofit-recipes",
+        "rel_path": "TeamViewer/TeamViewerQSCustom.download.recipe",
+        "reason": "newer duplicate (since 2018)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "6 dependent recipes"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2013-09 vs 2018-01"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to TeamViewerQS recipes in the hjuutilainen-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "46f933ae9b86",
+    "recipe_type": "download",
+    "app_name": "Termius",
+    "verdict": "recommend",
+    "confidence": "MEDIUM",
+    "keep": [
+      {
+        "repo": "davidbpirie-recipes",
+        "rel_path": "Termius/Termius.download.recipe.yaml",
+        "reason": "has CodeSignatureVerifier"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "ygini-recipes",
+        "rel_path": "Termius/Termius.download.recipe",
+        "reason": "missing CodeSignatureVerifier"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "has CodeSignatureVerifier"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "no CodeSignatureVerifier"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2023-08 vs 2016-05"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": "keep"
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "deprecate"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": "deprecate"
+      }
+    ],
+    "deprecation_message": "Consider switching to Termius recipes in the davidbpirie-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "2 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "446f12d31ab1",
+    "recipe_type": "download",
+    "app_name": "Thonny",
+    "verdict": "recommend",
+    "confidence": "HIGH",
+    "keep": [
+      {
+        "repo": "dataJAR-recipes",
+        "rel_path": "Thonny/Thonny.download.recipe",
+        "reason": "has CodeSignatureVerifier"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "peshay-recipes",
+        "rel_path": "Thonny/Thonny.download.recipe",
+        "reason": "missing CodeSignatureVerifier"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "has CodeSignatureVerifier; more resilient source (github vs url); 2 dependent recipes"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "no CodeSignatureVerifier; less resilient source (url)"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2017-02 vs 2016-09"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": "keep"
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": "keep"
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "deprecate"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to Thonny recipes in the dataJAR-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "8cfd4cf97368",
+    "recipe_type": "download",
+    "app_name": "Topaz Gigapixel",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "rderewianko-recipes",
+        "rel_path": "TopazGigapixel/TopazGigapixel.download.recipe",
+        "reason": "established since 2017"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "markkenny-recipes",
+        "rel_path": "Topaz/TopazGigapixel.download.recipe.yaml",
+        "reason": "newer duplicate (since 2024)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2017-11 vs 2024-01"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": "keep"
+      }
+    ],
+    "deprecation_message": "Consider switching to Topaz Gigapixel recipes in the rderewianko-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "e3109ff2f688",
+    "recipe_type": "download",
+    "app_name": "Touch\u00e9",
+    "verdict": "recommend",
+    "confidence": "HIGH",
+    "keep": [
+      {
+        "repo": "ahousseini-recipes",
+        "rel_path": "Touche/Touche.download.recipe",
+        "reason": "has CodeSignatureVerifier"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "jaharmi-recipes",
+        "rel_path": "RedSweater/Touche.download.recipe",
+        "reason": "missing CodeSignatureVerifier"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "has CodeSignatureVerifier"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "no CodeSignatureVerifier"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2020-06 vs 2016-11"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": "keep"
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "deprecate"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to Touch\u00e9 recipes in the ahousseini-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "107061635702",
+    "recipe_type": "download",
+    "app_name": "Tower",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "homebysix-recipes",
+        "rel_path": "Tower/Tower.download.recipe",
+        "reason": "4 dependents"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "Lotusshaney-recipes",
+        "rel_path": "Tower/Tower.download.recipe",
+        "reason": "newer duplicate (since 2022)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "4 dependent recipes"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2014-09 vs 2022-10"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to Tower recipes in the homebysix-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "2 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "58471f28bd53",
+    "recipe_type": "download",
+    "app_name": "Transmit",
+    "verdict": "recommend",
+    "confidence": "HIGH",
+    "keep": [
+      {
+        "repo": "recipes",
+        "rel_path": "Panic/Transmit.download.recipe",
+        "reason": "has CodeSignatureVerifier"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "keeleysam-recipes",
+        "rel_path": "Panic/Transmit.download.recipe",
+        "reason": "missing CodeSignatureVerifier"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "has CodeSignatureVerifier; 2 dependent recipes"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "no CodeSignatureVerifier"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": "keep"
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "deprecate"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to Transmit recipes in the recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "c1faec7d42e5",
+    "recipe_type": "download",
+    "app_name": "Typora",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "faumac-recipes",
+        "rel_path": "Typora/Typora.download.recipe",
+        "reason": "established since 2019"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "andrewvalentine-recipes",
+        "rel_path": "typora/typora.download.recipe",
+        "reason": "functionally equivalent duplicate"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "more resilient source (sparkle vs url)"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "less resilient source (url)"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2019-09 vs 2016-01"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": "keep"
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "deprecate"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to Typora recipes in the faumac-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "3 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "ac5a8034243d",
+    "recipe_type": "download",
+    "app_name": "UI Browser",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "wardsparadox-recipes",
+        "rel_path": "William Cheeseman/UI Browser.download.recipe",
+        "reason": "3 dependents"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "ahousseini-recipes",
+        "rel_path": "UI Browser/UI Browser.download.recipe",
+        "reason": "newer duplicate (since 2020)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "3 dependent recipes"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2017-12 vs 2020-05"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to UI Browser recipes in the wardsparadox-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "7ff37218e933",
+    "recipe_type": "download",
+    "app_name": "Unison",
+    "verdict": "skip",
+    "skip_reason": "different products (Unison file synchronizer vs Panic Unison Usenet client)"
+  },
+  {
+    "set_id": "4e1596eb88e5",
+    "recipe_type": "download",
+    "app_name": "VeraCrypt",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "andrewvalentine-recipes",
+        "rel_path": "VeraCrypt/VeraCrypt.download.recipe",
+        "reason": "established since 2016"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "dataJAR-recipes",
+        "rel_path": "VeraCrypt/VeraCrypt.download.recipe",
+        "reason": "newer duplicate (since 2018)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2016-01 vs 2018-03"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to VeraCrypt recipes in the andrewvalentine-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "2 child recipe(s) across 2 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "5b8c8df78f8d",
+    "recipe_type": "download",
+    "app_name": "Viber",
+    "verdict": "recommend",
+    "confidence": "MEDIUM",
+    "keep": [
+      {
+        "repo": "moofit-recipes",
+        "rel_path": "Viber/Viber.download.recipe.yaml",
+        "reason": "has CodeSignatureVerifier"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "joshua-d-miller-recipes",
+        "rel_path": "Viber/Viber.download.recipe",
+        "reason": "missing CodeSignatureVerifier"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "has CodeSignatureVerifier"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "no CodeSignatureVerifier"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2023-03 vs 2014-02"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": "keep"
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "deprecate"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": "deprecate"
+      }
+    ],
+    "deprecation_message": "Consider switching to Viber recipes in the moofit-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "424d36ebbdcc",
+    "recipe_type": "download",
+    "app_name": "Warp",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "homebysix-recipes",
+        "rel_path": "Warp/Warp.download.recipe",
+        "reason": "4 dependents"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "jaharmi-recipes",
+        "rel_path": "Warp/Warp.download.recipe",
+        "reason": "newer duplicate (since 2015)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "4 dependent recipes"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2014-09 vs 2015-12"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to Warp recipes in the homebysix-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "3 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "6482f59d3c4f",
+    "recipe_type": "download",
+    "app_name": "Webex",
+    "verdict": "recommend",
+    "confidence": "MEDIUM",
+    "keep": [
+      {
+        "repo": "smithjw-recipes",
+        "rel_path": "Cisco/Webex.download.recipe.yaml",
+        "reason": "multi-arch support"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "TekTekkers-recipes",
+        "rel_path": "Webex/Webex.download.recipe",
+        "reason": "no architecture variable"
+      },
+      {
+        "repo": "precursorca-recipes",
+        "rel_path": "Cisco/Webex.download.recipe",
+        "reason": "no architecture variable"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "has architecture input variable for arm64/x64 selection; more resilient source (url vs None)"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "no architecture variable"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "no architecture variable; less resilient source (None)"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2021-11 vs 2020-10"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2021-11 vs 2017-10"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": "keep"
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "deprecate"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": "deprecate"
+      }
+    ],
+    "deprecation_message": "Consider switching to Webex recipes in the smithjw-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "4 child recipe(s) across 2 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "43d9670cddd4",
+    "recipe_type": "download",
+    "app_name": "WebStorm",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "mosen-recipes",
+        "rel_path": "JetBrains/WebStorm.download.recipe",
+        "reason": "established since 2013"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "moofit-recipes",
+        "rel_path": "JetBrains/WebStormUniversal.download.recipe.yaml",
+        "reason": "newer duplicate (since 2023)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2013-10 vs 2023-05"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": "keep"
+      }
+    ],
+    "deprecation_message": "Consider switching to WebStorm recipes in the mosen-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "7f0740aa2b11",
+    "recipe_type": "download",
+    "app_name": "yo",
+    "verdict": "recommend",
+    "confidence": "MEDIUM",
+    "keep": [
+      {
+        "repo": "homebysix-recipes",
+        "rel_path": "yo/yo.download.recipe",
+        "reason": "uses original sheagcraig/yo repo"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "moofit-recipes",
+        "rel_path": "moof IT/yo.download.recipe",
+        "reason": "uses moofit/yo fork of the original"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use EndOfCheckPhase"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2017-12 vs 2021-05"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": "deprecate"
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to yo recipes in the homebysix-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "8421f9a1a517",
+    "recipe_type": "download",
+    "app_name": "yubico-authenticator",
+    "verdict": "recommend",
+    "confidence": "MEDIUM",
+    "keep": [
+      {
+        "repo": "n8felton-recipes",
+        "rel_path": "Yubico/yubico-authenticator.download.recipe",
+        "reason": "3 dependents"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "Lotusshaney-recipes",
+        "rel_path": "Yubico Authenticator/Yubico Authenticator.download.recipe",
+        "reason": "newer duplicate (since 2022)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "more resilient source (github vs url); 3 dependent recipes"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "less resilient source (url)"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2016-08 vs 2022-10"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": "keep"
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to yubico-authenticator recipes in the n8felton-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "925593c3fe57",
+    "recipe_type": "download",
+    "app_name": "Zulip",
+    "verdict": "recommend",
+    "confidence": "HIGH",
+    "keep": [
+      {
+        "repo": "keeleysam-recipes",
+        "rel_path": "Zulip/Zulip.download.recipe",
+        "reason": "uses current zulip.com download URL with architecture variable; has CodeSignatureVerifier; 5 dependents"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "ygini-recipes",
+        "rel_path": "Zulip/ZulipElectron.download.recipe",
+        "reason": "uses deprecated zulip-electron GitHub repo (renamed); no CodeSignatureVerifier"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "has architecture input variable for arm64/x64 selection; has CodeSignatureVerifier"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "no CodeSignatureVerifier; no architecture variable"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2013-09 vs 2015-11"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": "keep"
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": "keep"
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to Zulip recipes in the keeleysam-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "11473db570a2",
+    "recipe_type": "download",
+    "app_name": "AllSight",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "jazzace-recipes",
+        "rel_path": "Sassafras/SassafrasAllSight.download.recipe",
+        "reason": "4 dependents"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "vmiller-recipes",
+        "rel_path": "Sassafras/SassafrasAllSight.download.recipe",
+        "reason": "newer duplicate (since 2025)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase, unknown source (processor:CaseChanger)"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2020-08 vs 2025-10"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to AllSight recipes in the jazzace-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "5 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "cc6e0f7588c5",
+    "recipe_type": "download",
+    "app_name": "AutoCAD",
+    "verdict": "skip",
+    "skip_reason": "different product variants (AutoCAD current vs AutoCAD Legacy, different download methods)"
+  },
+  {
+    "set_id": "51a9ea6be7d4",
+    "recipe_type": "download",
+    "app_name": "AzulZuluJava",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "davidbpirie-recipes",
+        "rel_path": "AzulZuluJava/AzulZuluJava.download.recipe.yaml",
+        "reason": "multi-arch support"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "Lotusshaney-recipes",
+        "rel_path": "AzulZuluJava/AzulZuluJava.download.recipe",
+        "reason": "newer duplicate (since 2024)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use EndOfCheckPhase, unknown source (processor:AzulZuluJavaInfoProvider)"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2022-09 vs 2024-12"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": "deprecate"
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": "deprecate"
+      }
+    ],
+    "deprecation_message": "Consider switching to AzulZuluJava recipes in the davidbpirie-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "0521e2d1514e",
+    "recipe_type": "download",
+    "app_name": "BlackmagicDesktopVideo",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "dataJAR-recipes",
+        "rel_path": "Blackmagic Desktop Video/Blackmagic Desktop Video.download.recipe",
+        "reason": "has CodeSignatureVerifier"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "w0-recipes",
+        "rel_path": "DesktopVideo/BlackmagicDesktopVideo.download.recipe.yaml",
+        "reason": "newer duplicate (since 2024)"
+      },
+      {
+        "repo": "davidbpirie-recipes",
+        "rel_path": "Blackmagic/BlackmagicDesktopVideo.download.recipe.yaml",
+        "reason": "missing CodeSignatureVerifier"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use EndOfCheckPhase, unknown source (processor:BlackMagicURLProvider)"
+      },
+      {
+        "category": "favors_keep",
+        "text": "has CodeSignatureVerifier; 2 dependent recipes"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "no CodeSignatureVerifier"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2023-09 vs 2024-06"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2023-09 vs 2023-12"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": "keep"
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": "keep"
+      }
+    ],
+    "deprecation_message": "Consider switching to BlackmagicDesktopVideo recipes in the dataJAR-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "2 child recipe(s) across 2 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "5b24287b41ab",
+    "recipe_type": "download",
+    "app_name": "DataGrip",
+    "verdict": "skip",
+    "skip_reason": "different scope (DataGrip-specific recipe vs generic JetBrains recipe template)"
+  },
+  {
+    "set_id": "bda6a50ac788",
+    "recipe_type": "download",
+    "app_name": "GoToMeeting",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "homebysix-recipes",
+        "rel_path": "GoToMeeting/GoToMeeting.download.recipe",
+        "reason": "4 dependents"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "ahousseini-recipes",
+        "rel_path": "GoToMeeting/GoToMeeting.download.recipe",
+        "reason": "newer duplicate (since 2020)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "4 dependent recipes"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2014-09 vs 2020-05"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to GoToMeeting recipes in the homebysix-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "d1e74ca575c4",
+    "recipe_type": "download",
+    "app_name": "LibreOffice",
+    "verdict": "recommend",
+    "confidence": "MEDIUM",
+    "keep": [
+      {
+        "repo": "hjuutilainen-recipes",
+        "rel_path": "LibreOffice/LibreOffice.download.recipe",
+        "reason": "multi-arch support; release channel variable; 6 dependents"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "jpiel-recipes",
+        "rel_path": "Localized-LibreOffice/Localized-LibreOffice.download.recipe",
+        "reason": "newer duplicate (since 2017)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "6 dependent recipes"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2013-09 vs 2017-10"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to LibreOffice recipes in the hjuutilainen-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "14d249236156",
+    "recipe_type": "download",
+    "app_name": "Microsoft Edge",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "n8felton-recipes",
+        "rel_path": "Microsoft/MicrosoftEdge.download.recipe",
+        "reason": "release channel variable"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "rtrouton-recipes",
+        "rel_path": "MicrosoftEdge/MicrosoftEdge.download.recipe",
+        "reason": "no release variable"
+      },
+      {
+        "repo": "smithjw-recipes",
+        "rel_path": "Microsoft_Edge/Microsoft_Edge_alt.download.recipe.yaml",
+        "reason": "no release variable"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "has release channel input variable"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "no release variable"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "no release variable"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2016-08 vs 2017-11"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2016-08 vs 2024-02"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": "keep"
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": "keep"
+      }
+    ],
+    "deprecation_message": "Consider switching to Microsoft Edge recipes in the n8felton-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "3 child recipe(s) across 2 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "b2491f38b3f4",
+    "recipe_type": "download",
+    "app_name": "Opera",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "keeleysam-recipes",
+        "rel_path": "Opera/Opera.download.recipe",
+        "reason": "3 dependents"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "bochoven-recipes",
+        "rel_path": "Opera/Opera.download.recipe",
+        "reason": "newer duplicate (since 2014)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2013-08 vs 2014-09"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to Opera recipes in the keeleysam-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "3 child recipe(s) across 3 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "af4d62742f19",
+    "recipe_type": "download",
+    "app_name": "R",
+    "verdict": "recommend",
+    "confidence": "MEDIUM",
+    "keep": [
+      {
+        "repo": "hjuutilainen-recipes",
+        "rel_path": "R/R.download.recipe",
+        "reason": "multi-arch support; 4 dependents"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "homebysix-recipes",
+        "rel_path": "R/R.download.recipe",
+        "reason": "newer duplicate (since 2014)"
+      },
+      {
+        "repo": "MLBZ521-recipes",
+        "rel_path": "R/R-Universal.download.recipe.yaml",
+        "reason": "newer duplicate (since 2022)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "more resilient source (url vs unknown)"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "less resilient source (unknown)"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "less resilient source (unknown)"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2013-09 vs 2014-09"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2013-09 vs 2022-11"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": "keep"
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": "keep"
+      }
+    ],
+    "deprecation_message": "Consider switching to R recipes in the hjuutilainen-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "5 child recipe(s) across 3 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "8a3d697e650c",
+    "recipe_type": "download",
+    "app_name": "Terraform",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "jc0b-recipes",
+        "rel_path": "Hashicorp/TerraformUniversal.download.recipe.yaml",
+        "reason": "has CodeSignatureVerifier"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "timsutton-recipes",
+        "rel_path": "HashiCorp/Terraform.download.recipe",
+        "reason": "missing CodeSignatureVerifier"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use EndOfCheckPhase, unknown source (processor:HashiCorpURLProvider)"
+      },
+      {
+        "category": "favors_keep",
+        "text": "has CodeSignatureVerifier"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "no CodeSignatureVerifier"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2024-01 vs 2013-11"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": "keep"
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": "deprecate"
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "deprecate"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": "deprecate"
+      }
+    ],
+    "deprecation_message": "Consider switching to Terraform recipes in the jc0b-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "51aa9dbe399f",
+    "recipe_type": "download",
+    "app_name": "Xcode",
+    "verdict": "recommend",
+    "confidence": "MEDIUM",
+    "keep": [
+      {
+        "repo": "nmcspadden-recipes",
+        "rel_path": "Xcode/Xcode.download.recipe",
+        "reason": "established since 2022"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "smithjw-recipes",
+        "rel_path": "Xcode/Xcode.download.recipe.yaml",
+        "reason": "functionally equivalent duplicate"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "favors_keep",
+        "text": "has EndOfCheckPhase; 2 dependent recipes"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "no EndOfCheckPhase"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2022-08 vs 2021-05"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": "deprecate"
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": "keep"
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "deprecate"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": "keep"
+      }
+    ],
+    "deprecation_message": "Consider switching to Xcode recipes in the nmcspadden-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "da6e45b55838",
+    "recipe_type": "download",
+    "app_name": "XMind",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "peshay-recipes",
+        "rel_path": "Xmind/XMind.download.recipe",
+        "reason": "established since 2016"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "ahousseini-recipes",
+        "rel_path": "XMind/XMind.download.recipe",
+        "reason": "newer duplicate (since 2020)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2016-05 vs 2020-05"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to XMind recipes in the peshay-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "14d68338dca2",
+    "recipe_type": "download",
+    "app_name": "BetterDisplay",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "dataJAR-recipes",
+        "rel_path": "BetterDisplay/BetterDisplay.download.recipe",
+        "reason": "3 dependents"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "peetinc-recipes",
+        "rel_path": "BetterDisplay/BetterDisplay.download.recipe",
+        "reason": "newer duplicate (since 2019)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase, sparkle source (betterdisplay.pro/betterdisplay/sparkle/appcast.xml)"
+      },
+      {
+        "category": "favors_keep",
+        "text": "3 dependent recipes"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2017-01 vs 2019-11"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to BetterDisplay recipes in the dataJAR-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "ddc4a4d5704a",
+    "recipe_type": "download",
+    "app_name": "Scribe Desktop",
+    "verdict": "recommend",
+    "confidence": "MEDIUM",
+    "keep": [
+      {
+        "repo": "dataJAR-recipes",
+        "rel_path": "Scribe Desktop/Scribe Desktop.download.recipe",
+        "reason": "multi-arch support; has CodeSignatureVerifier"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "markkenny-recipes",
+        "rel_path": "ScribeDesktop/ScribeDesktop.download.recipe.yaml",
+        "reason": "no architecture variable"
+      },
+      {
+        "repo": "markkenny-recipes",
+        "rel_path": "ScribeDesktop/ScribeDesktop-UNIVERSAL.download.recipe.yaml",
+        "reason": "missing CodeSignatureVerifier; no architecture variable"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use EndOfCheckPhase, sparkle source (colony-labs-public.s3.us-east-2.amazonaws.com/macos-updates/appcast.xml)"
+      },
+      {
+        "category": "favors_keep",
+        "text": "has architecture input variable for arm64/x64 selection; has CodeSignatureVerifier"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "no architecture variable"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "no CodeSignatureVerifier; no architecture variable"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2017-01 vs 2024-01"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2017-01 vs 2026-02"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": "keep"
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": "keep"
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": "keep"
+      }
+    ],
+    "deprecation_message": "Consider switching to Scribe Desktop recipes in the dataJAR-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "2 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "d964d6c2468f",
+    "recipe_type": "download",
+    "app_name": "AppCleaner",
+    "verdict": "recommend",
+    "confidence": "MEDIUM",
+    "keep": [
+      {
+        "repo": "d33t5-recipes",
+        "rel_path": "AppCleaner/AppCleaner.download.recipe",
+        "reason": "has CodeSignatureVerifier"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "jleggat-recipes",
+        "rel_path": "AppCleaner/AppCleaner.download.recipe",
+        "reason": "missing CodeSignatureVerifier"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use EndOfCheckPhase, sparkle source (freemacsoft.net/appcleaner/updates.xml)"
+      },
+      {
+        "category": "favors_keep",
+        "text": "has CodeSignatureVerifier"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "no CodeSignatureVerifier"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2020-05 vs 2013-10"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": "keep"
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "deprecate"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to AppCleaner recipes in the d33t5-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "6 child recipe(s) across 5 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "0cfa3e713bc7",
+    "recipe_type": "download",
+    "app_name": "iTerm2",
+    "verdict": "recommend",
+    "confidence": "MEDIUM",
+    "keep": [
+      {
+        "repo": "hjuutilainen-recipes",
+        "rel_path": "iTerm2/iTerm2.download.recipe",
+        "reason": "release channel variable; 4 dependents"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "keeleysam-recipes",
+        "rel_path": "iTerm2/iTerm2.download.recipe",
+        "reason": "no release variable"
+      },
+      {
+        "repo": "smithjw-recipes",
+        "rel_path": "iTerm2/iTerm2.download.recipe.yaml",
+        "reason": "no release variable"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "has release channel input variable; more resilient source (sparkle vs url); 4 dependent recipes"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "no release variable"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "no release variable; less resilient source (url)"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2013-09 vs 2013-08"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2013-09 vs 2021-11"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": "keep"
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": "keep"
+      }
+    ],
+    "deprecation_message": "Consider switching to iTerm2 recipes in the hjuutilainen-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "2 child recipe(s) across 2 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "9b360e9950ff",
+    "recipe_type": "download",
+    "app_name": "Maestral",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "jaharmi-recipes",
+        "rel_path": "Maestral/Maestral.download.recipe",
+        "reason": "3 dependents"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "macprince-recipes",
+        "rel_path": "Sam Schott/Maestral.download.recipe",
+        "reason": "newer duplicate (since 2017)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase, sparkle source (maestral.app/appcast.xml)"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2015-12 vs 2017-03"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to Maestral recipes in the jaharmi-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "3 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "28c2f0382e35",
+    "recipe_type": "download",
+    "app_name": "ChatGPT Atlas",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "jannheider-recipes",
+        "rel_path": "OpenAI/ChatGPT-Atlas.download.recipe",
+        "reason": "3 dependents"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "aanklewicz-recipes",
+        "rel_path": "ChatGPT Atlas/ChatGPT Atlas.download.recipe",
+        "reason": "newer duplicate (since 2023)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase, sparkle source (persistent.oaistatic.com/atlas/public/sparkle_public_appcast.xml)"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2021-06 vs 2023-03"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to ChatGPT Atlas recipes in the jannheider-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "3 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "37cafe304b31",
+    "recipe_type": "download",
+    "app_name": "TeXLiveUtility",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "grahampugh-recipes",
+        "rel_path": "TeX/TeXLiveUtility.download.recipe.yaml",
+        "reason": "has CodeSignatureVerifier"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "bnpl-recipes",
+        "rel_path": "TeXLiveUtility/TeXLiveUtility.download.recipe",
+        "reason": "newer duplicate (since 2020)"
+      },
+      {
+        "repo": "scriptingosx-recipes",
+        "rel_path": "TeXLiveUtility/TeXLiveUtility.download.recipe",
+        "reason": "missing CodeSignatureVerifier"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "has CodeSignatureVerifier"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "no CodeSignatureVerifier"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2018-10 vs 2020-05"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2018-10 vs 2014-03"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": "keep"
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "deprecate"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": "deprecate"
+      }
+    ],
+    "deprecation_message": "Consider switching to TeXLiveUtility recipes in the grahampugh-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "2 child recipe(s) across 2 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "49ca3a44b4c5",
+    "recipe_type": "download",
+    "app_name": "ScummVM",
+    "verdict": "recommend",
+    "confidence": "HIGH",
+    "keep": [
+      {
+        "repo": "macprince-recipes",
+        "rel_path": "ScummVM Team/ScummVM.download.recipe",
+        "reason": "has CodeSignatureVerifier; 3 dependents"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "jaharmi-recipes",
+        "rel_path": "ScummVM/ScummVM.download.recipe",
+        "reason": "missing CodeSignatureVerifier"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use EndOfCheckPhase, sparkle source (www.scummvm.org/appcasts/macosx/release.xml)"
+      },
+      {
+        "category": "favors_keep",
+        "text": "has CodeSignatureVerifier"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "no CodeSignatureVerifier"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2017-03 vs 2015-12"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": "keep"
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "deprecate"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to ScummVM recipes in the macprince-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "3 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "cf6ce9f298cc",
+    "recipe_type": "download",
+    "app_name": "3DCoat",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "hansen-m-recipes",
+        "rel_path": "3DCoat/3DCoat.download.recipe",
+        "reason": "established since 2013"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "scriptingosx-recipes",
+        "rel_path": "3DCoat/3DCoat.download.recipe",
+        "reason": "newer duplicate (since 2014)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use EndOfCheckPhase, url source (3dcoat.com/download)"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2013-11 vs 2014-03"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": "deprecate"
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to 3DCoat recipes in the hansen-m-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "917528ba4339",
+    "recipe_type": "download",
+    "app_name": "Eclipse Temurin 11",
+    "verdict": "skip",
+    "skip_reason": "different formats (signed PKG installer vs raw binary tar.gz from same API)"
+  },
+  {
+    "set_id": "511c7c2d7857",
+    "recipe_type": "download",
+    "app_name": "Eclipse Temurin 8",
+    "verdict": "skip",
+    "skip_reason": "different formats (signed PKG installer vs raw binary tar.gz from same API)"
+  },
+  {
+    "set_id": "3f0e0470b5d8",
+    "recipe_type": "download",
+    "app_name": "GitHub Desktop",
+    "verdict": "skip",
+    "skip_reason": "different architecture handling approaches (single arch vs dual-download universal)"
+  },
+  {
+    "set_id": "539f950d416c",
+    "recipe_type": "download",
+    "app_name": "FCSExpress7Research",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "dataJAR-recipes",
+        "rel_path": "FCS Express 7 Research/FCS Express 7 Research.download.recipe",
+        "reason": "established since 2018"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "moofit-recipes",
+        "rel_path": "FCS Express/FCSExpress.download.recipe.yaml",
+        "reason": "newer duplicate (since 2023)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase, url source (denovosoftware.com/download-landing/fcsexpress7cytometryinstallation-mac.dmg)"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2018-03 vs 2023-05"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": "keep"
+      }
+    ],
+    "deprecation_message": "Consider switching to FCSExpress7Research recipes in the dataJAR-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "7bb96ced9923",
+    "recipe_type": "download",
+    "app_name": "AdobeUninstaller",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "jazzace-recipes",
+        "rel_path": "AdobeUninstaller/AdobeUninstaller.download.recipe",
+        "reason": "established since 2014"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "davidbpirie-recipes",
+        "rel_path": "AdobeUninstaller/AdobeUninstaller.download.recipe.yaml",
+        "reason": "newer duplicate (since 2024)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase, url source (deploymenttools.acp.adobeoobe.com/uninstall/mac/adobeuninstaller.dmg)"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2014-09 vs 2024-08"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": "keep"
+      }
+    ],
+    "deprecation_message": "Consider switching to AdobeUninstaller recipes in the jazzace-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "b99a606261a4",
+    "recipe_type": "download",
+    "app_name": "Canva",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "dataJAR-recipes",
+        "rel_path": "Canva/Canva.download.recipe",
+        "reason": "established since 2017"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "moofit-recipes",
+        "rel_path": "Canva/Canva.download.recipe.yaml",
+        "reason": "newer duplicate (since 2022)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase, url source (desktop-release.canva.com/latest-mac.yml)"
+      },
+      {
+        "category": "favors_keep",
+        "text": "2 dependent recipes"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2017-02 vs 2022-05"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": "keep"
+      }
+    ],
+    "deprecation_message": "Consider switching to Canva recipes in the dataJAR-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "c423f7fd8317",
+    "recipe_type": "download",
+    "app_name": "Miro",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "dataJAR-recipes",
+        "rel_path": "Miro/Miro.download.recipe",
+        "reason": "has CodeSignatureVerifier; 4 dependents"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "wegotoeleven-recipes",
+        "rel_path": "Miro/MiroUniversal.download.recipe.yaml",
+        "reason": "newer duplicate (since 2023)"
+      },
+      {
+        "repo": "moofit-recipes",
+        "rel_path": "Miro/MiroUniversal.download.recipe.yaml",
+        "reason": "newer duplicate (since 2023)"
+      },
+      {
+        "repo": "peshay-recipes",
+        "rel_path": "miro/miro.download.recipe",
+        "reason": "missing CodeSignatureVerifier"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "has CodeSignatureVerifier; 4 dependent recipes"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "no CodeSignatureVerifier"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2018-03 vs 2023-02"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2018-03 vs 2023-06"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2018-03 vs 2019-03"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": "keep"
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": "keep"
+      }
+    ],
+    "deprecation_message": "Consider switching to Miro recipes in the dataJAR-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "3 child recipe(s) across 3 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "fa11c3611cc1",
+    "recipe_type": "download",
+    "app_name": "AndroidStudio",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "novaksam-recipes",
+        "rel_path": "Recipes - Download/AndroidStudio.download.recipe",
+        "reason": "multi-arch support; 3 dependents"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "novaksam-recipes",
+        "rel_path": "Recipes - Download/AndroidStudio-Universal.download.recipe",
+        "reason": "newer duplicate (since 2022)"
+      },
+      {
+        "repo": "smithjw-recipes",
+        "rel_path": "Android Studio/Android_Studio.download.recipe.yaml",
+        "reason": "newer duplicate (since 2022)"
+      },
+      {
+        "repo": "kevinmcox-recipes",
+        "rel_path": "Google/AndroidStudio.download.recipe",
+        "reason": "newer duplicate (since 2025)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "more resilient source (url vs unknown); 3 dependent recipes"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "less resilient source (unknown)"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2015-04 vs 2022-11"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2015-04 vs 2022-05"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2015-04 vs 2025-05"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": "keep"
+      }
+    ],
+    "deprecation_message": "Consider switching to AndroidStudio recipes in the novaksam-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "3 child recipe(s) across 3 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "deba2a4286b6",
+    "recipe_type": "download",
+    "app_name": "YubicoPivTool",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "rderewianko-recipes",
+        "rel_path": "YubicoPivTool/YubicoPivTool.download.recipe",
+        "reason": "established since 2017"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "discentem-recipes",
+        "rel_path": "Yubico/YubicoPivTool.download.recipe.yaml",
+        "reason": "newer duplicate (since 2021)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase, url source (developers.yubico.com/yubico-piv-tool/releases)"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2017-11 vs 2021-08"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": "keep"
+      }
+    ],
+    "deprecation_message": "Consider switching to YubicoPivTool recipes in the rderewianko-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "d425623eb318",
+    "recipe_type": "download",
+    "app_name": "GoogleEarthPro",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "nstrauss-recipes",
+        "rel_path": "Google Earth Pro/GoogleEarthPro.download.recipe",
+        "reason": "established since 2017"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "dataJAR-recipes",
+        "rel_path": "Google Earth Pro/Google Earth Pro.download.recipe",
+        "reason": "newer duplicate (since 2017)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase, url source (dl.google.com/earth/client/advanced/current/googleearthpromac-intel.dmg)"
+      },
+      {
+        "category": "favors_keep",
+        "text": "2 dependent recipes"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2017-01 vs 2017-07"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to GoogleEarthPro recipes in the nstrauss-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "a4392e86f98f",
+    "recipe_type": "download",
+    "app_name": "DotNet 8 SDK",
+    "verdict": "recommend",
+    "confidence": "MEDIUM",
+    "keep": [
+      {
+        "repo": "dataJAR-recipes",
+        "rel_path": "DotNet 8 SDK/DotNet 8 SDK.download.recipe",
+        "reason": "multi-arch support"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "markkenny-recipes",
+        "rel_path": "Microsoft DotNet/DotNet 8 SDK-Universal.download.recipe.yaml",
+        "reason": "no architecture variable"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase, url source (dotnet.microsoft.com/en-us/download/dotnet/8.0)"
+      },
+      {
+        "category": "favors_keep",
+        "text": "has architecture input variable for arm64/x64 selection"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "no architecture variable"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2019-08 vs 2025-01"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": "keep"
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": "keep"
+      }
+    ],
+    "deprecation_message": "Consider switching to DotNet 8 SDK recipes in the dataJAR-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "dcd6c99b627a",
+    "recipe_type": "download",
+    "app_name": "DotNet 9 SDK",
+    "verdict": "recommend",
+    "confidence": "MEDIUM",
+    "keep": [
+      {
+        "repo": "dataJAR-recipes",
+        "rel_path": "DotNet 9 SDK/DotNet 9 SDK.download.recipe",
+        "reason": "multi-arch support"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "markkenny-recipes",
+        "rel_path": "Microsoft DotNet/DotNet 9 SDK-Universal.download.recipe.yaml",
+        "reason": "no architecture variable"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase, url source (dotnet.microsoft.com/en-us/download/dotnet/9.0)"
+      },
+      {
+        "category": "favors_keep",
+        "text": "has architecture input variable for arm64/x64 selection"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "no architecture variable"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2019-08 vs 2025-01"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": "keep"
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": "keep"
+      }
+    ],
+    "deprecation_message": "Consider switching to DotNet 9 SDK recipes in the dataJAR-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "46a8e6628f42",
+    "recipe_type": "download",
+    "app_name": "NVivo 15",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "dataJAR-recipes",
+        "rel_path": "NVivo 15/NVivo 15.download.recipe",
+        "reason": "established since 2017"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "MLBZ521-recipes",
+        "rel_path": "NVivo/NVivo15.download.recipe.yaml",
+        "reason": "newer duplicate (since 2024)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase, url source (download.qsrinternational.com/software/nvivo15formac/nvivo15.dmg)"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2017-01 vs 2024-09"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": "keep"
+      }
+    ],
+    "deprecation_message": "Consider switching to NVivo 15 recipes in the dataJAR-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "3925e444856f",
+    "recipe_type": "download",
+    "app_name": "NVivo",
+    "verdict": "skip",
+    "skip_reason": "different product versions (NVivo current vs NVivo 12, 11, 10)"
+  },
+  {
+    "set_id": "022965cce609",
+    "recipe_type": "download",
+    "app_name": "Spotify",
+    "verdict": "recommend",
+    "confidence": "MEDIUM",
+    "keep": [
+      {
+        "repo": "recipes",
+        "rel_path": "Spotify/Spotify.download.recipe",
+        "reason": "multi-arch support; 5 dependents"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "MLBZ521-recipes",
+        "rel_path": "Spotify/Spotify-Universal.download.recipe.yaml",
+        "reason": "newer duplicate (since 2023)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase, url source (download.scdn.co/spotifyarm64.dmg)"
+      },
+      {
+        "category": "favors_keep",
+        "text": "5 dependent recipes"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2013-08 vs 2023-06"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": "keep"
+      }
+    ],
+    "deprecation_message": "Consider switching to Spotify recipes in the recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "2bf9d0dbe4d3",
+    "recipe_type": "download",
+    "app_name": "1Password",
+    "verdict": "skip",
+    "skip_reason": "different product versions (1Password 8 PKG vs 1Password 7 ZIP vs different download formats)"
+  },
+  {
+    "set_id": "30bd8967fced",
+    "recipe_type": "download",
+    "app_name": "Finale",
+    "verdict": "skip",
+    "skip_reason": "different product versions (Finale 27 vs Finale 26 Trial)"
+  },
+  {
+    "set_id": "0f635eb8868f",
+    "recipe_type": "download",
+    "app_name": "EV3 Classroom",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "nstrauss-recipes",
+        "rel_path": "Lego Mindstorms/LegoMindstormsEducationEV3Classroom.download.recipe",
+        "reason": "established since 2017"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "dataJAR-recipes",
+        "rel_path": "EV3 Classroom/EV3 Classroom.download.recipe",
+        "reason": "newer duplicate (since 2018)"
+      },
+      {
+        "repo": "ahousseini-recipes",
+        "rel_path": "EV3 Classroom/EV3 Classroom.download.recipe",
+        "reason": "newer duplicate (since 2020)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "more resilient source (url vs unknown)"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "less resilient source (unknown)"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2017-01 vs 2018-03"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2017-01 vs 2020-05"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to EV3 Classroom recipes in the nstrauss-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "2 child recipe(s) across 2 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "bc028b24231f",
+    "recipe_type": "download",
+    "app_name": "FileZilla",
+    "verdict": "recommend",
+    "confidence": "MEDIUM",
+    "keep": [
+      {
+        "repo": "wycomco-recipes",
+        "rel_path": "FileZilla/Filezilla.download.recipe",
+        "reason": "multi-arch support"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "primalcurve-recipes",
+        "rel_path": "FileZilla/FileZilla.multiarch.download.recipe",
+        "reason": "no architecture variable"
+      },
+      {
+        "repo": "moofit-recipes",
+        "rel_path": "FileZilla/FileZilla-Universal.download.recipe.yaml",
+        "reason": "no architecture variable"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "has architecture input variable for arm64/x64 selection"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "no architecture variable"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "no architecture variable"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2025-11 vs 2024-01"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2025-11 vs 2024-11"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": "keep"
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "deprecate"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": "keep"
+      }
+    ],
+    "deprecation_message": "Consider switching to FileZilla recipes in the wycomco-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "2 child recipe(s) across 2 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "47eb8edb7cb8",
+    "recipe_type": "download",
+    "app_name": "Ghostty",
+    "verdict": "recommend",
+    "confidence": "MEDIUM",
+    "keep": [
+      {
+        "repo": "wardsparadox-recipes",
+        "rel_path": "Ghostty/Ghostty.download.recipe.yaml",
+        "reason": "Canonical recipe per ownership-transfer note; 4 downstream dependents across two repos"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "dataJAR-recipes",
+        "rel_path": "Ghostty/Ghostty.download.recipe",
+        "reason": "Functionally equivalent (same URLTextSearcher pattern, same code requirement) but only 1 dependent and no ownership signal"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both scrape ghostty.org/download with URLTextSearcher to extract the release.files.ghostty.org DMG URL, both have CodeSignatureVerifier with the same com.mitchellh.ghostty / 24VZTF6M5V requirement, and both have EndOfCheckPhase."
+      },
+      {
+        "category": "favors_keep",
+        "text": "wardsparadox carries an explicit 'Originally created by @discentem, ownership transferred' comment and has 4 downstream dependents (almenscorner-recipes, wardsparadox-recipes children)."
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "dataJAR has only 1 dependent and no ownership signal; the recipe-tracked first_commit (2018) appears to be a git-follow artifact rather than the actual recipe age."
+      },
+      {
+        "category": "tiebreaker",
+        "text": "dataJAR is plist (slight format preference), but dependent count and ownership note outweigh format here."
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier present",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase present",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Same HTML scrape source",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Ownership transfer note",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Plist vs YAML",
+        "favors": "deprecate"
+      }
+    ],
+    "deprecation_message": "Consider switching to Ghostty recipes in the wardsparadox-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe across 1 repo",
+    "existing_prs": []
+  },
+  {
+    "set_id": "6e4fbc6fa66c",
+    "recipe_type": "download",
+    "app_name": "Amazon Coretto JDK 17",
+    "verdict": "skip",
+    "skip_reason": "different architectures (Intel vs Apple Silicon downloads for same JDK)"
+  },
+  {
+    "set_id": "aa1cce5c4f60",
+    "recipe_type": "download",
+    "app_name": "MicrosoftAutoUpdate",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "rtrouton-recipes",
+        "rel_path": "MicrosoftAutoUpdate/MicrosoftAutoUpdate.download.recipe",
+        "reason": "established since 2017"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "jlehikoinen-recipes",
+        "rel_path": "MicrosoftAutoUpdate/MicrosoftAutoUpdate.download.recipe",
+        "reason": "newer duplicate (since 2019)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase, url source (go.microsoft.com/fwlink/?linkid=830196)"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2017-11 vs 2019-03"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to MicrosoftAutoUpdate recipes in the rtrouton-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "3721c0f6aa24",
+    "recipe_type": "download",
+    "app_name": "Creative Cloud Installer",
+    "verdict": "skip",
+    "skip_reason": "different architectures (Intel vs Apple Silicon vs Universal Creative Cloud installers)"
+  },
+  {
+    "set_id": "352bc4e7281c",
+    "recipe_type": "download",
+    "app_name": "OpenJDK 21",
+    "verdict": "skip",
+    "skip_reason": "different architectures (x64 vs arm64 OpenJDK builds)"
+  },
+  {
+    "set_id": "f208dc99400f",
+    "recipe_type": "download",
+    "app_name": "Brave",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "apettinen-recipes",
+        "rel_path": "Brave/Brave.download.recipe",
+        "reason": "4 dependents"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "moofit-recipes",
+        "rel_path": "Brave/BraveUniversal.download.recipe.yaml",
+        "reason": "newer duplicate (since 2022)"
+      },
+      {
+        "repo": "swy-recipes",
+        "rel_path": "BraveUniversal/BraveUniversal.download.recipe",
+        "reason": "newer duplicate (since 2017)"
+      },
+      {
+        "repo": "drewdiver-recipes",
+        "rel_path": "Brave/Brave.download.recipe",
+        "reason": "newer duplicate (since 2018)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "4 dependent recipes"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2016-11 vs 2022-01"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2016-11 vs 2017-06"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2016-11 vs 2018-12"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": "keep"
+      }
+    ],
+    "deprecation_message": "Consider switching to Brave recipes in the apettinen-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "5 child recipe(s) across 3 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "357c6eb55384",
+    "recipe_type": "download",
+    "app_name": "LivestreamStudio",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "apizz-recipes",
+        "rel_path": "Livestream/LivestreamStudio.download.recipe",
+        "reason": "established since 2017"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "davidbpirie-recipes",
+        "rel_path": "Livestream/LivestreamStudio.download.recipe.yaml",
+        "reason": "newer duplicate (since 2024)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase, url source (livestreamstudio.net/macosx/livestreamstudio.pkg)"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2017-05 vs 2024-02"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": "keep"
+      }
+    ],
+    "deprecation_message": "Consider switching to LivestreamStudio recipes in the apizz-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "d4f8ed94c607",
+    "recipe_type": "download",
+    "app_name": "macdown",
+    "verdict": "recommend",
+    "confidence": "MEDIUM",
+    "keep": [
+      {
+        "repo": "jleggat-recipes",
+        "rel_path": "MacDown/MacDown.download.recipe",
+        "reason": "5 dependents"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "grahampugh-recipes",
+        "rel_path": "MacDown/MacDown.download.recipe.yaml",
+        "reason": "newer duplicate (since 2023)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use EndOfCheckPhase, url source (macdown.uranusjr.com/download/latest)"
+      },
+      {
+        "category": "favors_keep",
+        "text": "5 dependent recipes"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2015-06 vs 2023-05"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": "deprecate"
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": "keep"
+      }
+    ],
+    "deprecation_message": "Consider switching to macdown recipes in the jleggat-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "2 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "18f04e64f47d",
+    "recipe_type": "download",
+    "app_name": "MediaInfo",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "bnpl-recipes",
+        "rel_path": "MediaInfo/MediaInfo.download.recipe",
+        "reason": "established since 2016"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "moofit-recipes",
+        "rel_path": "MediaArea/MediaInfo.download.recipe",
+        "reason": "newer duplicate (since 2017)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase, url source (mediaarea.net/en/mediainfo/download/mac_os)"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2016-05 vs 2017-06"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to MediaInfo recipes in the bnpl-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "8f89a97c6308",
+    "recipe_type": "download",
+    "app_name": "Microsoft Teams",
+    "verdict": "skip",
+    "skip_reason": "different products (Microsoft Teams new vs Microsoft Teams Classic)"
+  },
+  {
+    "set_id": "4b2df161a0a5",
+    "recipe_type": "download",
+    "app_name": "Sleep Aid",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "homebysix-recipes",
+        "rel_path": "Ohanaware/SleepAid.download.recipe",
+        "reason": "4 dependents"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "jaharmi-recipes",
+        "rel_path": "Ohanaware/SleepAid.download.recipe",
+        "reason": "newer duplicate (since 2015)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase, url source (ohanaware.com/sleepaid/sleep_aid.dmg)"
+      },
+      {
+        "category": "favors_keep",
+        "text": "4 dependent recipes"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2014-09 vs 2015-12"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to Sleep Aid recipes in the homebysix-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "3 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "61eae045eaa9",
+    "recipe_type": "download",
+    "app_name": "ChatGPT",
+    "verdict": "skip",
+    "skip_reason": "different products (ChatGPT desktop app vs ChatGPT Atlas/Work variant)"
+  },
+  {
+    "set_id": "8c89e3804e4b",
+    "recipe_type": "download",
+    "app_name": "LaTeXiT",
+    "verdict": "recommend",
+    "confidence": "HIGH",
+    "keep": [
+      {
+        "repo": "scriptingosx-recipes",
+        "rel_path": "LaTeXiT/LaTeXiT.download.recipe",
+        "reason": "has CodeSignatureVerifier"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "grahampugh-recipes",
+        "rel_path": "TeX/LaTeXiT.download.recipe.yaml",
+        "reason": "missing CodeSignatureVerifier"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use EndOfCheckPhase, url source (pierre.chachatelier.fr/latexit/)"
+      },
+      {
+        "category": "favors_keep",
+        "text": "has CodeSignatureVerifier"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "no CodeSignatureVerifier"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2014-03 vs 2018-10"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": "keep"
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": "keep"
+      }
+    ],
+    "deprecation_message": "Consider switching to LaTeXiT recipes in the scriptingosx-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "79790c3484d2",
+    "recipe_type": "download",
+    "app_name": "Tailscale",
+    "verdict": "skip",
+    "skip_reason": "different channels and formats (stable DMG vs stable PKG vs unstable)"
+  },
+  {
+    "set_id": "6a68c40531bf",
+    "recipe_type": "download",
+    "app_name": "Vectorworks",
+    "verdict": "skip",
+    "skip_reason": "different product versions and formats (Vectorworks 2024 vs 2025 Install Manager vs 2026 PKG)"
+  },
+  {
+    "set_id": "88cd3532e303",
+    "recipe_type": "download",
+    "app_name": "Remotix",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "gmarnin-recipes",
+        "rel_path": "Remotix/Remotix.download.recipe",
+        "reason": "established since 2015"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "ahousseini-recipes",
+        "rel_path": "Remotix/Remotix.download.recipe",
+        "reason": "newer duplicate (since 2020)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase, url source (remotix.com/downloads/latest-remotix-mac)"
+      },
+      {
+        "category": "favors_keep",
+        "text": "2 dependent recipes"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2015-03 vs 2020-05"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to Remotix recipes in the gmarnin-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "ee6197642028",
+    "recipe_type": "download",
+    "app_name": "Hive",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "swy-recipes",
+        "rel_path": "Hive/Hive.download.recipe",
+        "reason": "3 dependents"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "markkenny-recipes",
+        "rel_path": "Hive/Hive.download.recipe.yaml",
+        "reason": "newer duplicate (since 2024)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase, url source (s3.amazonaws.com/hv-desktop-mac/hiveinstaller.dmg)"
+      },
+      {
+        "category": "favors_keep",
+        "text": "3 dependent recipes"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2017-06 vs 2024-01"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": "keep"
+      }
+    ],
+    "deprecation_message": "Consider switching to Hive recipes in the swy-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "73ecccdc7b1a",
+    "recipe_type": "download",
+    "app_name": "sipgate softphone",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "ahousseini-recipes",
+        "rel_path": "sipgatesoftphone/sipgatesoftphone.download.recipe",
+        "reason": "established since 2020"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "wycomco-recipes",
+        "rel_path": "sipgate_softphone/sipgate-softphone.download.recipe",
+        "reason": "newer duplicate (since 2020)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase, url source (sipgate-desktop-app.s3.eu-central-1.amazonaws.com/sipgate-softphone.dmg)"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2020-05 vs 2020-09"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to sipgate softphone recipes in the ahousseini-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "6ecc0d61993e",
+    "recipe_type": "download",
+    "app_name": "DjView",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "scriptingosx-recipes",
+        "rel_path": "DjView/DjView.download.recipe",
+        "reason": "established since 2014"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "grahampugh-recipes",
+        "rel_path": "DJView/DjView.download.recipe.yaml",
+        "reason": "newer duplicate (since 2018)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use EndOfCheckPhase, url source (sourceforge.net/projects/djvu/rss?path=/djvulibre_macos)"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2014-03 vs 2018-09"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": "deprecate"
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": "keep"
+      }
+    ],
+    "deprecation_message": "Consider switching to DjView recipes in the scriptingosx-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "9ad6a0bdb6b9",
+    "recipe_type": "download",
+    "app_name": "STAN4J",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "bnpl-recipes",
+        "rel_path": "STAN4J/STAN4J.download.recipe",
+        "reason": "established since 2016"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "dataJAR-recipes",
+        "rel_path": "STAN4J/STAN4J.download.recipe",
+        "reason": "newer duplicate (since 2018)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use EndOfCheckPhase, url source (stan4j.com/download/app)"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2016-05 vs 2018-02"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": "deprecate"
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to STAN4J recipes in the bnpl-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "4723df52c5e9",
+    "recipe_type": "download",
+    "app_name": "Steam",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "haircut-recipes",
+        "rel_path": "Valve/Steam.download.recipe",
+        "reason": "3 dependents"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "moofit-recipes",
+        "rel_path": "Valve/steam.download.recipe",
+        "reason": "newer duplicate (since 2018)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase, url source (steamcdn-a.akamaihd.net/client/installer/steam.dmg)"
+      },
+      {
+        "category": "favors_keep",
+        "text": "3 dependent recipes"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2018-05 vs 2018-06"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to Steam recipes in the haircut-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "e1850424c1f0",
+    "recipe_type": "download",
+    "app_name": "SubEthaEdit",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "hansen-m-recipes",
+        "rel_path": "CodingMonkeys/SubEthaEdit.download.recipe",
+        "reason": "established since 2013"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "apettinen-recipes",
+        "rel_path": "SubEthaEdit/SubEthaEdit.download.recipe",
+        "reason": "newer duplicate (since 2018)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase, url source (subethaedit.net/subethaedit.zip)"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2013-11 vs 2018-11"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to SubEthaEdit recipes in the hansen-m-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "2 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "be8e98b999da",
+    "recipe_type": "download",
+    "app_name": "TablePlus",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "flywire-recipes",
+        "rel_path": "TablePlus/TablePlus.download.recipe",
+        "reason": "3 dependents"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "paul-cossey-recipes",
+        "rel_path": "TablePlus/TablePlus.download.recipe",
+        "reason": "newer duplicate (since 2021)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase, url source (tableplus.com/release/osx/tableplus_latest)"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2019-05 vs 2021-01"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to TablePlus recipes in the flywire-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "4 child recipe(s) across 2 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "8eb7f5613f96",
+    "recipe_type": "download",
+    "app_name": "TopazPhotoAI",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "markkenny-recipes",
+        "rel_path": "Topaz/TopazPhotoAI.download.recipe.yaml",
+        "reason": "established since 2024"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "jps3-recipes",
+        "rel_path": "Topaz/TopazPhotoAI.download.recipe.yaml",
+        "reason": "newer duplicate (since 2024)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase, url source (topazlabs.com/d/photo/latest/mac/full)"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2024-01 vs 2024-09"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to TopazPhotoAI recipes in the markkenny-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "d7d9e44f8a7f",
+    "recipe_type": "download",
+    "app_name": "TopazVideoAI",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "TekTekkers-recipes",
+        "rel_path": "Topaz/TopazVideoAI.download.recipe",
+        "reason": "established since 2020"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "jps3-recipes",
+        "rel_path": "Topaz/TopazVideoAI.download.recipe.yaml",
+        "reason": "newer duplicate (since 2024)"
+      },
+      {
+        "repo": "markkenny-recipes",
+        "rel_path": "Topaz/TopazVideoAI.download.recipe.yaml",
+        "reason": "newer duplicate (since 2024)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase, url source (topazlabs.com/d/tvai/latest/mac/full)"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2020-10 vs 2024-09"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2020-10 vs 2024-11"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": "keep"
+      }
+    ],
+    "deprecation_message": "Consider switching to TopazVideoAI recipes in the TekTekkers-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "2 child recipe(s) across 2 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "eda463cc81f1",
+    "recipe_type": "download",
+    "app_name": "Signal",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "jaharmi-recipes",
+        "rel_path": "Signal/Signal.download.recipe",
+        "reason": "4 dependents"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "crystalllized-recipes",
+        "rel_path": "Signal/Signal.download.recipe",
+        "reason": "newer duplicate (since 2018)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase, url source (updates.signal.org/desktop/latest-mac.yml)"
+      },
+      {
+        "category": "favors_keep",
+        "text": "4 dependent recipes"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2015-12 vs 2018-01"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to Signal recipes in the jaharmi-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "8b12d6159172",
+    "recipe_type": "download",
+    "app_name": "WhatsApp",
+    "verdict": "recommend",
+    "confidence": "MEDIUM",
+    "keep": [
+      {
+        "repo": "scriptingosx-recipes",
+        "rel_path": "WhatsAppInc/WhatsApp.download.recipe",
+        "reason": "10 years older, 4 dependents across two repos, exposes DOWNLOAD_URL as an Input variable for easy override"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "gmarnin-recipes",
+        "rel_path": "WhatsApp/WhatsApp.download.recipe",
+        "reason": "Functionally equivalent (same direct URL, same code requirement) but newly added (2026-04-14) with only 1 dependent"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both download from web.whatsapp.com/desktop/mac_native/release/?configuration=Release, both have CodeSignatureVerifier with the same net.whatsapp.WhatsApp / 57T9237FN3 requirement, and both have EndOfCheckPhase."
+      },
+      {
+        "category": "favors_keep",
+        "text": "scriptingosx exposes DOWNLOAD_URL as an Input variable so downstream recipes can override the URL without forking; 4 downstream dependents include peshay-recipes children."
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "gmarnin hardcodes the URL inside URLDownloader and was added 2026-04-14 with only 1 dependent."
+      },
+      {
+        "category": "tiebreaker",
+        "text": "scriptingosx first committed 2016-04-13; gmarnin first committed 2026-04-14 (a decade later). Both are plist."
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier present",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase present",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Same direct URL source",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "DOWNLOAD_URL exposed as Input",
+        "favors": "keep"
+      },
+      {
+        "key": "history",
+        "label": "Earlier first commit (2016 vs 2026)",
+        "favors": "keep"
+      }
+    ],
+    "deprecation_message": "Consider switching to WhatsApp recipes in the scriptingosx-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "none",
+    "existing_prs": []
+  },
+  {
+    "set_id": "1c28094cf005",
+    "recipe_type": "download",
+    "app_name": "4KVideoDownloaderPlus",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "dataJAR-recipes",
+        "rel_path": "4K Video DownloaderPlus/4K Video DownloaderPlus.download.recipe",
+        "reason": "established since 2017"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "markkenny-recipes",
+        "rel_path": "4K Video DownloaderPlus/4K Video DownloaderPlus.download.recipe.yaml",
+        "reason": "newer duplicate (since 2024)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase, url source (www.4kdownload.com/thanks-for-downloading?source=videodownloaderplus)"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2017-01 vs 2024-10"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": "keep"
+      }
+    ],
+    "deprecation_message": "Consider switching to 4KVideoDownloaderPlus recipes in the dataJAR-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "14c865e4b6a2",
+    "recipe_type": "download",
+    "app_name": "Anaconda",
+    "verdict": "recommend",
+    "confidence": "MEDIUM",
+    "keep": [
+      {
+        "repo": "hansen-m-recipes",
+        "rel_path": "Continuum/Anaconda.download.recipe",
+        "reason": "multi-arch support; 7 dependents"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "MLBZ521-recipes",
+        "rel_path": "Anaconda/Anaconda-Universal.download.recipe.yaml",
+        "reason": "newer duplicate (since 2023)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use EndOfCheckPhase, url source (www.anaconda.com/download/success)"
+      },
+      {
+        "category": "favors_keep",
+        "text": "7 dependent recipes"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2013-11 vs 2023-06"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": "deprecate"
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": "keep"
+      }
+    ],
+    "deprecation_message": "Consider switching to Anaconda recipes in the hansen-m-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "70136542670b",
+    "recipe_type": "download",
+    "app_name": "PostgreSQL",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "almenscorner-recipes",
+        "rel_path": "PostgreSQL/PostgreSQLVersionSpecific.download.recipe",
+        "reason": "3 dependents"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "wholtz-recipes",
+        "rel_path": "postgresql/PostgreSQL.download.recipe",
+        "reason": "functionally equivalent duplicate"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase, url source (www.enterprisedb.com/downloads/postgres-postgresql-downloads)"
+      },
+      {
+        "category": "favors_keep",
+        "text": "3 dependent recipes"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2025-03 vs 2018-01"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "deprecate"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to PostgreSQL recipes in the almenscorner-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "ea4389f74dd7",
+    "recipe_type": "download",
+    "app_name": "UniversalTypeClient7",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "jessepeterson-recipes",
+        "rel_path": "Extensis/UniversalTypeClient7.download.recipe",
+        "reason": "established since 2013"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "Darkomen78-recipes",
+        "rel_path": "UniversalTypeClient7/UniversalTypeClient7.download.recipe",
+        "reason": "newer duplicate (since 2019)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use EndOfCheckPhase, url source (www.extensis.com/support/universal-type-server-7)"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2013-10 vs 2019-12"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": "deprecate"
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to UniversalTypeClient7 recipes in the jessepeterson-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "2 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "acccf736bbe4",
+    "recipe_type": "download",
+    "app_name": "FabFilterProC2",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "dataJAR-recipes",
+        "rel_path": "FabFilter Pro-C 2/FabFilter Pro-C 2.download.recipe",
+        "reason": "established since 2020"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "davidbpirie-recipes",
+        "rel_path": "FabFilter/FabFilterProC2.download.recipe.yaml",
+        "reason": "newer duplicate (since 2025)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase, url source (www.fabfilter.com/download)"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2020-05 vs 2025-08"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": "keep"
+      }
+    ],
+    "deprecation_message": "Consider switching to FabFilterProC2 recipes in the dataJAR-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "6ce1d21197cd",
+    "recipe_type": "download",
+    "app_name": "FabFilterProL2",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "dataJAR-recipes",
+        "rel_path": "FabFilter Pro-L 2/FabFilter Pro-L 2.download.recipe",
+        "reason": "established since 2020"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "davidbpirie-recipes",
+        "rel_path": "FabFilter/FabFilterProL2.download.recipe.yaml",
+        "reason": "newer duplicate (since 2025)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase, url source (www.fabfilter.com/download)"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2020-05 vs 2025-08"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": "keep"
+      }
+    ],
+    "deprecation_message": "Consider switching to FabFilterProL2 recipes in the dataJAR-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "9d9956a109b2",
+    "recipe_type": "download",
+    "app_name": "Final Draft 12",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "n8felton-recipes",
+        "rel_path": "FinalDraft/FinalDraft12.download.recipe",
+        "reason": "established since 2016"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "moofit-recipes",
+        "rel_path": "Final Draft 12/FinalDraft12.download.recipe.yaml",
+        "reason": "newer duplicate (since 2023)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase, url source (www.finaldraft.com/support/install-final-draft/install-final-draft-12-macintosh)"
+      },
+      {
+        "category": "favors_keep",
+        "text": "2 dependent recipes"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2016-10 vs 2023-01"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": "keep"
+      }
+    ],
+    "deprecation_message": "Consider switching to Final Draft 12 recipes in the n8felton-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "66c8ae2b2df6",
+    "recipe_type": "download",
+    "app_name": "GIMP",
+    "verdict": "skip",
+    "skip_reason": "Different patterns: hjuutilainen-recipes ships a single-arch download parameterized by an ARCH input variable, while MLBZ521-recipes and moofit-recipes ship pseudo-universal recipes that download both arm64 and x86_64 DMGs in one run for downstream combined packaging. GIMP does not publish a true universal binary, so per the evaluation rules pseudo-universal variants are ignored when comparing \u2014 leaving the hjuutilainen recipe with no like-for-like duplicate."
+  },
+  {
+    "set_id": "baabd71d2eb0",
+    "recipe_type": "download",
+    "app_name": "jamovi",
+    "verdict": "recommend",
+    "confidence": "HIGH",
+    "keep": [
+      {
+        "repo": "novaksam-recipes",
+        "rel_path": "Jamovi/Jamovi.download.recipe",
+        "reason": "multi-arch support; release channel variable"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "n8felton-recipes",
+        "rel_path": "jamovi/jamovi.download.recipe",
+        "reason": "no architecture variable; no release variable"
+      },
+      {
+        "repo": "ahousseini-recipes",
+        "rel_path": "jamovi/jamovi.download.recipe",
+        "reason": "no architecture variable; no release variable"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "has architecture input variable for arm64/x64 selection; has release channel input variable; more resilient source (url vs unknown); 2 dependent recipes"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "no architecture variable; no release variable"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "no architecture variable; no release variable; less resilient source (unknown)"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2024-10 vs 2016-08"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2024-10 vs 2020-05"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": "keep"
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": "keep"
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "deprecate"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to jamovi recipes in the novaksam-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "2 child recipe(s) across 2 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "647feb0e26bc",
+    "recipe_type": "download",
+    "app_name": "Lucid",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "macvfx-recipes",
+        "rel_path": "Lucid/Lucid.download.recipe",
+        "reason": "established since 2021"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "markkenny-recipes",
+        "rel_path": "LucidLink/Lucid.download.recipe.yaml",
+        "reason": "newer duplicate (since 2025)"
+      },
+      {
+        "repo": "moofit-recipes",
+        "rel_path": "LucidLink/Lucid.download.recipe.yaml",
+        "reason": "newer duplicate (since 2022)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase, url source (www.lucidlink.com/download/latest/osx/stable)"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2021-12 vs 2025-04"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2021-12 vs 2022-06"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": "keep"
+      }
+    ],
+    "deprecation_message": "Consider switching to Lucid recipes in the macvfx-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "2 child recipe(s) across 2 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "48ef459eaa77",
+    "recipe_type": "download",
+    "app_name": "LucidLink",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "markkenny-recipes",
+        "rel_path": "LucidLink/LucidLink.download.recipe.yaml",
+        "reason": "established since 2024"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "thetornad0-recipes",
+        "rel_path": "LucidLink/LucidLink.download.recipe",
+        "reason": "newer duplicate (since 2026)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase, url source (www.lucidlink.com/download/new-ll-latest/macos/stable)"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2024-11 vs 2026-01"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": "deprecate"
+      }
+    ],
+    "deprecation_message": "Consider switching to LucidLink recipes in the markkenny-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "3 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "a13f00b46533",
+    "recipe_type": "download",
+    "app_name": "PlantronicsHub",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "blackthroat-recipes",
+        "rel_path": "Plantronics, Inc./PlantronicsHub.download.recipe",
+        "reason": "3 dependents"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "ahousseini-recipes",
+        "rel_path": "Plantronics Hub/Plantronics Hub.download.recipe",
+        "reason": "newer duplicate (since 2020)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase, url source (www.poly.com/content/dam/www/software/plantronicshubinstaller.dmg)"
+      },
+      {
+        "category": "favors_keep",
+        "text": "3 dependent recipes"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2017-12 vs 2020-05"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to PlantronicsHub recipes in the blackthroat-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "2 child recipe(s) across 2 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "98699a7b781a",
+    "recipe_type": "download",
+    "app_name": "Reaper",
+    "verdict": "recommend",
+    "confidence": "MEDIUM",
+    "keep": [
+      {
+        "repo": "orbsmiv-recipes",
+        "rel_path": "Reaper/Reaper.download.recipe",
+        "reason": "multi-arch support"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "moofit-recipes",
+        "rel_path": "Reaper/Reaper.download.recipe.yaml",
+        "reason": "no architecture variable"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase, url source (www.reaper.fm/download.php)"
+      },
+      {
+        "category": "favors_keep",
+        "text": "has architecture input variable for arm64/x64 selection; 2 dependent recipes"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "no architecture variable"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2016-10 vs 2022-05"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": "keep"
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": "keep"
+      }
+    ],
+    "deprecation_message": "Consider switching to Reaper recipes in the orbsmiv-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "347dae539100",
+    "recipe_type": "download",
+    "app_name": "SourceTree",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "hjuutilainen-recipes",
+        "rel_path": "Atlassian/SourceTree.download.recipe",
+        "reason": "4 dependents"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "faumac-recipes",
+        "rel_path": "Sourcetree/Sourcetree.download.recipe",
+        "reason": "newer duplicate (since 2021)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase, url source (www.sourcetreeapp.com)"
+      },
+      {
+        "category": "favors_keep",
+        "text": "4 dependent recipes"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2013-09 vs 2021-02"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to SourceTree recipes in the hjuutilainen-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "a2d29c7f45e3",
+    "recipe_type": "download",
+    "app_name": "SQLPro Studio",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "apizz-recipes",
+        "rel_path": "SQLPro_Studio/SQLProStudio.download.recipe",
+        "reason": "established since 2018"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "Lotusshaney-recipes",
+        "rel_path": "SQLPro Studio/SQLPro Studio.download.recipe",
+        "reason": "newer duplicate (since 2022)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase, url source (www.sqlprostudio.com/download.php)"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2018-03 vs 2022-10"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to SQLPro Studio recipes in the apizz-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "2ccd9b7d10e1",
+    "recipe_type": "download",
+    "app_name": "SmartGit",
+    "verdict": "skip",
+    "skip_reason": "different products (SmartGit git client vs ARM Forge debugging tool)"
+  },
+  {
+    "set_id": "70c7dfc93f62",
+    "recipe_type": "download",
+    "app_name": "Tableau Reader",
+    "verdict": "recommend",
+    "confidence": "MEDIUM",
+    "keep": [
+      {
+        "repo": "MLBZ521-recipes",
+        "rel_path": "Tableau/TableauReader-Universal.download.recipe.yaml",
+        "reason": "multi-arch support"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "homebysix-recipes",
+        "rel_path": "TableauReader/TableauReader.download.recipe",
+        "reason": "no architecture variable"
+      },
+      {
+        "repo": "foigus-recipes",
+        "rel_path": "Tableau/TableauReader.download.recipe",
+        "reason": "no architecture variable"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase"
+      },
+      {
+        "category": "favors_keep",
+        "text": "has architecture input variable for arm64/x64 selection; more resilient source (url vs None)"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "no architecture variable"
+      },
+      {
+        "category": "favors_deprecate",
+        "text": "no architecture variable; less resilient source (None)"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2024-09 vs 2014-09"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2024-09 vs 2015-06"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": "keep"
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "deprecate"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": "deprecate"
+      }
+    ],
+    "deprecation_message": "Consider switching to Tableau Reader recipes in the MLBZ521-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "3 child recipe(s) across 3 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "cd28e3669983",
+    "recipe_type": "download",
+    "app_name": "VirtualBox",
+    "verdict": "skip",
+    "skip_reason": "different formats (DMG app bundle vs PKG installer variants)"
+  },
+  {
+    "set_id": "e690a1828aad",
+    "recipe_type": "download",
+    "app_name": "Wireshark",
+    "verdict": "skip",
+    "skip_reason": "different channels (Wireshark stable release vs Wireshark development builds)"
+  },
+  {
+    "set_id": "962ee66a9aeb",
+    "recipe_type": "download",
+    "app_name": "Zoom",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "hansen-m-recipes",
+        "rel_path": "Zoom/Zoom.download.recipe",
+        "reason": "established since 2013"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "MLBZ521-recipes",
+        "rel_path": "Zoom/Zoom-ForIT.download.recipe",
+        "reason": "newer duplicate (since 2018)"
+      },
+      {
+        "repo": "Lotusshaney-recipes",
+        "rel_path": "Zoom/Zoom.download.recipe",
+        "reason": "newer duplicate (since 2024)"
+      },
+      {
+        "repo": "kkeilson-recipes",
+        "rel_path": "zoom.us/zoomIT.download.recipe",
+        "reason": "newer duplicate (since 2020)"
+      },
+      {
+        "repo": "smithjw-recipes",
+        "rel_path": "Zoom/Zoom_IT.download.recipe.yaml",
+        "reason": "newer duplicate (since 2021)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase, url source (zoom.us/client/latest/zoominstallerit.pkg)"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2013-11 vs 2018-05"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2013-11 vs 2024-10"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2013-11 vs 2020-11"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2013-11 vs 2021-11"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": "keep"
+      }
+    ],
+    "deprecation_message": "Consider switching to Zoom recipes in the hansen-m-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "5 child recipe(s) across 5 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "b81452653520",
+    "recipe_type": "download",
+    "app_name": "Zoom Outlook Plugin",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "joshua-d-miller-recipes",
+        "rel_path": "Zoom/ZoomOutlookPlugin.download.recipe",
+        "reason": "established since 2014"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "MLBZ521-recipes",
+        "rel_path": "Zoom/Zoom-OutlookPlugin.download.recipe",
+        "reason": "newer duplicate (since 2018)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase, url source (zoom.us/client/latest/zoommacoutlookplugin.pkg)"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2014-02 vs 2018-05"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to Zoom Outlook Plugin recipes in the joshua-d-miller-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "681b3bd8eb81",
+    "recipe_type": "download",
+    "app_name": "Zoom Rooms",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "smithjw-recipes",
+        "rel_path": "Zoom/ZoomRooms.download.recipe",
+        "reason": "established since 2017"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "gregneagle-recipes",
+        "rel_path": "Zoom/ZoomRooms.download.recipe",
+        "reason": "newer duplicate (since 2020)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase, url source (zoom.us/client/latest/zoomrooms.pkg)"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2017-04 vs 2020-07"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": null
+      }
+    ],
+    "deprecation_message": "Consider switching to Zoom Rooms recipes in the smithjw-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "1 child recipe(s) across 1 repo(s)",
+    "existing_prs": []
+  },
+  {
+    "set_id": "fd9c93f114f6",
+    "recipe_type": "download",
+    "app_name": "Zwift",
+    "verdict": "recommend",
+    "confidence": "LOW",
+    "keep": [
+      {
+        "repo": "andredb90-recipes",
+        "rel_path": "Zwift/Zwift.download.recipe",
+        "reason": "established since 2020"
+      }
+    ],
+    "deprecate": [
+      {
+        "repo": "moofit-recipes",
+        "rel_path": "Zwift/Zwift-moofit.download.recipe.yaml",
+        "reason": "newer duplicate (since 2023)"
+      }
+    ],
+    "rationale": [
+      {
+        "category": "shared",
+        "text": "Both use CodeSignatureVerifier, EndOfCheckPhase, url source (zwift.com/download/mac)"
+      },
+      {
+        "category": "tiebreaker",
+        "text": "first committed 2020-01 vs 2023-02"
+      }
+    ],
+    "criteria": [
+      {
+        "key": "codesig",
+        "label": "CodeSignatureVerifier",
+        "favors": null
+      },
+      {
+        "key": "endofcheck",
+        "label": "EndOfCheckPhase",
+        "favors": null
+      },
+      {
+        "key": "arch",
+        "label": "Multi-architecture support",
+        "favors": null
+      },
+      {
+        "key": "release",
+        "label": "Release channel variable",
+        "favors": null
+      },
+      {
+        "key": "source_resilience",
+        "label": "Source resilience",
+        "favors": null
+      },
+      {
+        "key": "metadata",
+        "label": "Metadata quality",
+        "favors": null
+      },
+      {
+        "key": "history",
+        "label": "Commit history",
+        "favors": "keep"
+      },
+      {
+        "key": "format",
+        "label": "Recipe format",
+        "favors": "keep"
+      }
+    ],
+    "deprecation_message": "Consider switching to Zwift recipes in the andredb90-recipes repo. This recipe is deprecated and will be removed in the future.",
+    "dependency_impact": "2 child recipe(s) across 2 repo(s)",
+    "existing_prs": []
+  }
+]

--- a/docs/dashboard.json
+++ b/docs/dashboard.json
@@ -1,13 +1,13 @@
 {
-  "generated_at": "2026-04-20T05:26:55.908961+00:00",
+  "generated_at": "2026-04-25T06:13:41.726538+00:00",
   "stats": {
     "HIGH": 28,
-    "MEDIUM": 74,
-    "LOW": 112,
-    "SKIP": 42,
-    "RESOLVED": 28
+    "MEDIUM": 77,
+    "LOW": 111,
+    "SKIP": 43,
+    "RESOLVED": 29
   },
-  "total_sets": 261,
+  "total_sets": 259,
   "needs_reassessment": 3,
   "repos_involved": [
     "Darkomen78-recipes",
@@ -67,7 +67,6 @@
     "justinrummel-recipes",
     "keeleysam-recipes",
     "kevinmcox-recipes",
-    "kitzy-recipes",
     "kkeilson-recipes",
     "macprince-recipes",
     "macvfx-recipes",
@@ -196,6 +195,13 @@
           "title": "Deprecate Anki recipes",
           "url": "https://github.com/autopkg/andrewzirkel-recipes/pull/14",
           "state": "open"
+        },
+        {
+          "repo": "dataJAR-recipes",
+          "number": 395,
+          "title": "Change parent recipe of Anki.munki",
+          "url": "https://github.com/autopkg/dataJAR-recipes/pull/395",
+          "state": "merged"
         },
         {
           "repo": "nstrauss-recipes",
@@ -731,66 +737,6 @@
       "dependency_impact": "1 child recipe(s) across 1 repo(s)"
     },
     {
-      "id": "0f29c7059fbc",
-      "app_name": "fleetctl",
-      "action_status": "resolved",
-      "existing_prs": [
-        {
-          "repo": "jc0b-recipes",
-          "number": 1,
-          "title": "Updated recipes to account for changes in Fleet",
-          "url": "https://github.com/autopkg/jc0b-recipes/pull/1",
-          "state": "merged"
-        }
-      ],
-      "member_count": 2,
-      "members_summary": [
-        {
-          "repo": "jc0b-recipes",
-          "rel_path": "Fleet/fleetctl.download.recipe.yaml",
-          "has_codesig": true,
-          "has_endofcheck": true,
-          "has_arch_var": false,
-          "dependent_count": 1
-        },
-        {
-          "repo": "kitzy-recipes",
-          "rel_path": "Fleet/fleetctl.download.recipe.yaml",
-          "has_codesig": false,
-          "has_endofcheck": true,
-          "has_arch_var": false,
-          "dependent_count": 1
-        }
-      ],
-      "confidence": "UNEVALUATED",
-      "keep": [],
-      "deprecate": [],
-      "rationale": "",
-      "criteria": [],
-      "deprecation_message": "",
-      "dependency_impact": "",
-      "candidate_members": [
-        {
-          "repo": "jc0b-recipes",
-          "rel_path": "Fleet/fleetctl.download.recipe.yaml",
-          "identifier": "com.github.jc0b.download.fleetctl",
-          "has_codesig": true,
-          "has_endofcheck": true,
-          "has_arch_var": false,
-          "source_type": "github"
-        },
-        {
-          "repo": "kitzy-recipes",
-          "rel_path": "Fleet/fleetctl.download.recipe.yaml",
-          "identifier": "com.github.kitzy.download.fleetctl",
-          "has_codesig": false,
-          "has_endofcheck": true,
-          "has_arch_var": false,
-          "source_type": "github"
-        }
-      ]
-    },
-    {
       "id": "e438d62a0d85",
       "app_name": "Dangerzone",
       "action_status": "needs_pr",
@@ -895,7 +841,7 @@
     {
       "id": "50c0df2285e9",
       "app_name": "Contour",
-      "action_status": "needs_evaluation",
+      "action_status": "needs_pr",
       "existing_prs": [],
       "member_count": 2,
       "members_summary": [
@@ -916,33 +862,68 @@
           "dependent_count": 1
         }
       ],
-      "confidence": "UNEVALUATED",
-      "keep": [],
-      "deprecate": [],
-      "rationale": "",
-      "criteria": [],
-      "deprecation_message": "",
-      "dependency_impact": "",
-      "candidate_members": [
+      "confidence": "MEDIUM",
+      "keep": [
         {
           "repo": "jc0b-recipes",
           "rel_path": "Contour/Contour.download.recipe.yaml",
-          "identifier": "com.github.jc0b.download.Contour",
-          "has_codesig": true,
-          "has_endofcheck": true,
-          "has_arch_var": false,
-          "source_type": "github"
-        },
+          "reason": "Older recipe with version normalization (strips 'v' prefix, converts '-beta' to 'b'); pins release_id to 'latest' for stability"
+        }
+      ],
+      "deprecate": [
         {
           "repo": "kevinmcox-recipes",
           "rel_path": "Henry Stamerjohann/Contour.download.recipe.yaml",
-          "identifier": "com.github.kevinmcox.download.Contour",
-          "has_codesig": true,
-          "has_endofcheck": true,
-          "has_arch_var": false,
-          "source_type": "github"
+          "reason": "Same source, no version normalization; written ~6 weeks after jc0b's recipe"
         }
-      ]
+      ],
+      "rationale": [
+        {
+          "category": "shared",
+          "text": "Both use GitHubReleasesInfoProvider against headmin/contour with the same asset_regex, both have CodeSignatureVerifier and EndOfCheckPhase, both expect the same Declarative IT GmbH (D6G4X4D7C9) signing identity."
+        },
+        {
+          "category": "favors_keep",
+          "text": "jc0b normalizes the version string via FindAndReplace (strips leading 'v', maps '-beta' to 'b') and explicitly sets release_id='latest' with sort_by_highest_tag_names=true."
+        },
+        {
+          "category": "favors_deprecate",
+          "text": "kevinmcox is a thinner wrapper without version normalization; tag/version output will include the upstream 'v' prefix."
+        },
+        {
+          "category": "tiebreaker",
+          "text": "jc0b first committed 2026-03-07; kevinmcox first committed 2026-04-18 (~6 weeks later)."
+        }
+      ],
+      "criteria": [
+        {
+          "key": "codesig",
+          "label": "CodeSignatureVerifier present",
+          "favors": null
+        },
+        {
+          "key": "endofcheck",
+          "label": "EndOfCheckPhase present",
+          "favors": null
+        },
+        {
+          "key": "source_resilience",
+          "label": "GitHub Releases (resilient)",
+          "favors": null
+        },
+        {
+          "key": "metadata",
+          "label": "Version normalization",
+          "favors": "keep"
+        },
+        {
+          "key": "history",
+          "label": "Earlier first commit",
+          "favors": "keep"
+        }
+      ],
+      "deprecation_message": "Consider switching to Contour recipes in the jc0b-recipes repo. This recipe is deprecated and will be removed in the future.",
+      "dependency_impact": "none"
     },
     {
       "id": "f537fb62f033",
@@ -1632,7 +1613,7 @@
     },
     {
       "id": "4254821ed59f",
-      "app_name": "Kitty",
+      "app_name": "kitty",
       "action_status": "pr_open",
       "existing_prs": [
         {
@@ -2312,7 +2293,7 @@
     },
     {
       "id": "0e123552c2b4",
-      "app_name": "Support Helper",
+      "app_name": "SupportHelper",
       "action_status": "needs_pr",
       "existing_prs": [],
       "member_count": 2,
@@ -2810,7 +2791,7 @@
     },
     {
       "id": "d597367390ec",
-      "app_name": "Affinity Designer",
+      "app_name": "AffinityDesigner",
       "action_status": "resolved",
       "existing_prs": [
         {
@@ -2912,7 +2893,7 @@
     },
     {
       "id": "bbcf43e8a24f",
-      "app_name": "Affinity Photo",
+      "app_name": "AffinityPhoto",
       "action_status": "resolved",
       "existing_prs": [
         {
@@ -3014,7 +2995,7 @@
     },
     {
       "id": "069af748c779",
-      "app_name": "Affinity Publisher",
+      "app_name": "AffinityPublisher",
       "action_status": "resolved",
       "existing_prs": [
         {
@@ -4077,15 +4058,8 @@
     {
       "id": "02d0c04ffa7d",
       "app_name": "BlueJ",
-      "action_status": "pr_open",
+      "action_status": "needs_pr",
       "existing_prs": [
-        {
-          "repo": "orchard-recipes",
-          "number": 50,
-          "title": "Deprecate BlueJ recipes",
-          "url": "https://github.com/autopkg/orchard-recipes/pull/50",
-          "state": "open"
-        },
         {
           "repo": "orchard-recipes",
           "number": 5,
@@ -5477,8 +5451,16 @@
     {
       "id": "f59f9692643b",
       "app_name": "Cryptomator",
-      "action_status": "needs_pr",
-      "existing_prs": [],
+      "action_status": "resolved",
+      "existing_prs": [
+        {
+          "repo": "ahousseini-recipes",
+          "number": 56,
+          "title": "Switch to HomebrewCaskURL",
+          "url": "https://github.com/autopkg/ahousseini-recipes/pull/56",
+          "state": "merged"
+        }
+      ],
       "member_count": 2,
       "members_summary": [
         {
@@ -5688,7 +5670,7 @@
     },
     {
       "id": "adc9d93c5678",
-      "app_name": "DCPomatic2",
+      "app_name": "DCP-o-matic2",
       "action_status": "needs_pr",
       "existing_prs": [],
       "member_count": 2,
@@ -5892,7 +5874,7 @@
     },
     {
       "id": "51ab490fcac2",
-      "app_name": "default-browser",
+      "app_name": "defaultbrowser",
       "action_status": "needs_pr",
       "existing_prs": [],
       "member_count": 2,
@@ -6726,7 +6708,7 @@
     },
     {
       "id": "a256e769f0fd",
-      "app_name": "erase-install",
+      "app_name": "EraseInstall",
       "action_status": "pr_open",
       "existing_prs": [
         {
@@ -6937,104 +6919,6 @@
         }
       ],
       "deprecation_message": "Consider switching to ExpressVPN recipes in the dataJAR-recipes repo. This recipe is deprecated and will be removed in the future.",
-      "dependency_impact": "1 child recipe(s) across 1 repo(s)"
-    },
-    {
-      "id": "f7f39a5042cb",
-      "app_name": "Extensis Connect",
-      "action_status": "needs_pr",
-      "existing_prs": [],
-      "member_count": 2,
-      "members_summary": [
-        {
-          "repo": "jannheider-recipes",
-          "rel_path": "Extensis/ExtensisConnect.download.recipe",
-          "has_codesig": true,
-          "has_endofcheck": true,
-          "has_arch_var": false,
-          "dependent_count": 3
-        },
-        {
-          "repo": "markkenny-recipes",
-          "rel_path": "Extensis/ExtensisConnect.download.recipe.yaml",
-          "has_codesig": true,
-          "has_endofcheck": true,
-          "has_arch_var": false,
-          "dependent_count": 1
-        }
-      ],
-      "confidence": "LOW",
-      "keep": [
-        {
-          "repo": "jannheider-recipes",
-          "rel_path": "Extensis/ExtensisConnect.download.recipe",
-          "reason": "3 dependents"
-        }
-      ],
-      "deprecate": [
-        {
-          "repo": "markkenny-recipes",
-          "rel_path": "Extensis/ExtensisConnect.download.recipe.yaml",
-          "reason": "newer duplicate (since 2024)"
-        }
-      ],
-      "rationale": [
-        {
-          "category": "shared",
-          "text": "Both use CodeSignatureVerifier, EndOfCheckPhase"
-        },
-        {
-          "category": "favors_keep",
-          "text": "3 dependent recipes"
-        },
-        {
-          "category": "tiebreaker",
-          "text": "first committed 2021-06 vs 2024-12"
-        }
-      ],
-      "criteria": [
-        {
-          "key": "codesig",
-          "label": "CodeSignatureVerifier",
-          "favors": null
-        },
-        {
-          "key": "endofcheck",
-          "label": "EndOfCheckPhase",
-          "favors": null
-        },
-        {
-          "key": "arch",
-          "label": "Multi-architecture support",
-          "favors": null
-        },
-        {
-          "key": "release",
-          "label": "Release channel variable",
-          "favors": null
-        },
-        {
-          "key": "source_resilience",
-          "label": "Source resilience",
-          "favors": null
-        },
-        {
-          "key": "metadata",
-          "label": "Metadata quality",
-          "favors": null
-        },
-        {
-          "key": "history",
-          "label": "Commit history",
-          "favors": "keep"
-        },
-        {
-          "key": "format",
-          "label": "Recipe format",
-          "favors": "keep"
-        }
-      ],
-      "deprecation_message": "Consider switching to Extensis Connect recipes in the jannheider-recipes repo. This recipe is deprecated and will be removed in the future.",
       "dependency_impact": "1 child recipe(s) across 1 repo(s)"
     },
     {
@@ -8181,16 +8065,8 @@
     {
       "id": "1fa5059aa6b6",
       "app_name": "Handbrake",
-      "action_status": "pr_open",
-      "existing_prs": [
-        {
-          "repo": "keeleysam-recipes",
-          "number": 205,
-          "title": "Deprecate Handbrake download recipe",
-          "url": "https://github.com/autopkg/keeleysam-recipes/pull/205",
-          "state": "open"
-        }
-      ],
+      "action_status": "needs_pr",
+      "existing_prs": [],
       "member_count": 2,
       "members_summary": [
         {
@@ -8780,17 +8656,9 @@
     },
     {
       "id": "6a8a00c04f50",
-      "app_name": "JetBrainsToolbox",
-      "action_status": "pr_open",
-      "existing_prs": [
-        {
-          "repo": "crystalllized-recipes",
-          "number": 17,
-          "title": "Deprecate JetBrains Toolbox recipes",
-          "url": "https://github.com/autopkg/crystalllized-recipes/pull/17",
-          "state": "open"
-        }
-      ],
+      "app_name": "JetBrains Toolbox",
+      "action_status": "needs_pr",
+      "existing_prs": [],
       "member_count": 2,
       "members_summary": [
         {
@@ -9001,7 +8869,7 @@
     },
     {
       "id": "1edb16973e77",
-      "app_name": "KeeperPasswordManager",
+      "app_name": "Keeper Password Manager",
       "action_status": "needs_pr",
       "existing_prs": [],
       "member_count": 2,
@@ -9197,7 +9065,7 @@
     },
     {
       "id": "8a3aad74485f",
-      "app_name": "KiteStudentPortal",
+      "app_name": "Kite Student Portal",
       "action_status": "pr_open",
       "existing_prs": [
         {
@@ -10142,7 +10010,7 @@
     },
     {
       "id": "85f377e747cf",
-      "app_name": "malwarebytes",
+      "app_name": "Malwarebytes",
       "action_status": "needs_pr",
       "existing_prs": [],
       "member_count": 2,
@@ -10175,7 +10043,7 @@
     },
     {
       "id": "7858eb674089",
-      "app_name": "Marked2",
+      "app_name": "Marked 2",
       "action_status": "needs_pr",
       "existing_prs": [],
       "member_count": 2,
@@ -10997,7 +10865,7 @@
     },
     {
       "id": "bf22efed0cd6",
-      "app_name": "mtr",
+      "app_name": "MTR",
       "action_status": "needs_pr",
       "existing_prs": [],
       "member_count": 2,
@@ -12674,7 +12542,7 @@
     },
     {
       "id": "df50c1e28024",
-      "app_name": "PrismaAccessBrowser",
+      "app_name": "Prisma Access Browser",
       "action_status": "needs_pr",
       "existing_prs": [],
       "member_count": 2,
@@ -13149,7 +13017,7 @@
     },
     {
       "id": "a7a1b23a1c87",
-      "app_name": "Read&Write",
+      "app_name": "ReadWrite",
       "action_status": "needs_pr",
       "existing_prs": [],
       "member_count": 2,
@@ -14806,7 +14674,7 @@
     },
     {
       "id": "46f933ae9b86",
-      "app_name": "Termius",
+      "app_name": "termius",
       "action_status": "needs_pr",
       "existing_prs": [],
       "member_count": 2,
@@ -16329,7 +16197,7 @@
     },
     {
       "id": "8421f9a1a517",
-      "app_name": "yubico-authenticator",
+      "app_name": "Yubico Authenticator",
       "action_status": "needs_pr",
       "existing_prs": [],
       "member_count": 2,
@@ -16534,14 +16402,14 @@
     {
       "id": "11473db570a2",
       "app_name": "AllSight",
-      "action_status": "needs_pr",
+      "action_status": "pr_open",
       "existing_prs": [
         {
           "repo": "jazzace-recipes",
           "number": 55,
           "title": "Deprecate migrated recipes",
           "url": "https://github.com/autopkg/jazzace-recipes/pull/55",
-          "state": "closed"
+          "state": "open"
         },
         {
           "repo": "vmiller-recipes",
@@ -17181,20 +17049,20 @@
           "dependent_count": 1
         },
         {
-          "repo": "rtrouton-recipes",
-          "rel_path": "MicrosoftEdge/MicrosoftEdge.download.recipe",
-          "has_codesig": true,
-          "has_endofcheck": true,
-          "has_arch_var": false,
-          "dependent_count": 2
-        },
-        {
           "repo": "smithjw-recipes",
           "rel_path": "Microsoft_Edge/Microsoft_Edge_alt.download.recipe.yaml",
           "has_codesig": true,
           "has_endofcheck": true,
           "has_arch_var": false,
           "dependent_count": 1
+        },
+        {
+          "repo": "rtrouton-recipes",
+          "rel_path": "MicrosoftEdge/MicrosoftEdge.download.recipe",
+          "has_codesig": true,
+          "has_endofcheck": true,
+          "has_arch_var": false,
+          "dependent_count": 2
         }
       ],
       "confidence": "LOW",
@@ -18882,17 +18750,17 @@
           "dependent_count": 1
         },
         {
-          "repo": "grahampugh-recipes",
-          "rel_path": "EclipseTemurin/EclipseTemurin8.download.recipe.yaml",
-          "has_codesig": false,
+          "repo": "novaksam-recipes",
+          "rel_path": "Recipes - Download/EclipseTemurin8.download.recipe",
+          "has_codesig": true,
           "has_endofcheck": true,
           "has_arch_var": true,
           "dependent_count": 1
         },
         {
-          "repo": "novaksam-recipes",
-          "rel_path": "Recipes - Download/EclipseTemurin8.download.recipe",
-          "has_codesig": true,
+          "repo": "grahampugh-recipes",
+          "rel_path": "EclipseTemurin/EclipseTemurin8.download.recipe.yaml",
+          "has_codesig": false,
           "has_endofcheck": true,
           "has_arch_var": true,
           "dependent_count": 1
@@ -19952,7 +19820,7 @@
     },
     {
       "id": "46a8e6628f42",
-      "app_name": "NVivo15",
+      "app_name": "NVivo 15",
       "action_status": "needs_pr",
       "existing_prs": [],
       "member_count": 2,
@@ -20280,14 +20148,6 @@
       "members_summary": [
         {
           "repo": "dataJAR-recipes",
-          "rel_path": "Finale 26-Trial/Finale26-Trial.download.recipe",
-          "has_codesig": true,
-          "has_endofcheck": true,
-          "has_arch_var": false,
-          "dependent_count": 1
-        },
-        {
-          "repo": "dataJAR-recipes",
           "rel_path": "Finale 27/Finale27.download.recipe",
           "has_codesig": true,
           "has_endofcheck": true,
@@ -20297,6 +20157,14 @@
         {
           "repo": "jazzace-recipes",
           "rel_path": "MakeMusic/Finale.download.recipe",
+          "has_codesig": true,
+          "has_endofcheck": true,
+          "has_arch_var": false,
+          "dependent_count": 1
+        },
+        {
+          "repo": "dataJAR-recipes",
+          "rel_path": "Finale 26-Trial/Finale26-Trial.download.recipe",
           "has_codesig": true,
           "has_endofcheck": true,
           "has_arch_var": false,
@@ -20329,6 +20197,14 @@
       "member_count": 3,
       "members_summary": [
         {
+          "repo": "ahousseini-recipes",
+          "rel_path": "EV3 Classroom/EV3 Classroom.download.recipe",
+          "has_codesig": true,
+          "has_endofcheck": true,
+          "has_arch_var": false,
+          "dependent_count": 1
+        },
+        {
           "repo": "dataJAR-recipes",
           "rel_path": "EV3 Classroom/EV3 Classroom.download.recipe",
           "has_codesig": true,
@@ -20339,14 +20215,6 @@
         {
           "repo": "nstrauss-recipes",
           "rel_path": "Lego Mindstorms/LegoMindstormsEducationEV3Classroom.download.recipe",
-          "has_codesig": true,
-          "has_endofcheck": true,
-          "has_arch_var": false,
-          "dependent_count": 1
-        },
-        {
-          "repo": "ahousseini-recipes",
-          "rel_path": "EV3 Classroom/EV3 Classroom.download.recipe",
           "has_codesig": true,
           "has_endofcheck": true,
           "has_arch_var": false,
@@ -20574,7 +20442,7 @@
     {
       "id": "47eb8edb7cb8",
       "app_name": "Ghostty",
-      "action_status": "needs_evaluation",
+      "action_status": "needs_pr",
       "existing_prs": [],
       "member_count": 2,
       "members_summary": [
@@ -20595,33 +20463,68 @@
           "dependent_count": 4
         }
       ],
-      "confidence": "UNEVALUATED",
-      "keep": [],
-      "deprecate": [],
-      "rationale": "",
-      "criteria": [],
-      "deprecation_message": "",
-      "dependency_impact": "",
-      "candidate_members": [
-        {
-          "repo": "dataJAR-recipes",
-          "rel_path": "Ghostty/Ghostty.download.recipe",
-          "identifier": "com.github.dataJAR-recipes.download.Ghostty",
-          "has_codesig": true,
-          "has_endofcheck": true,
-          "has_arch_var": false,
-          "source_type": "url"
-        },
+      "confidence": "MEDIUM",
+      "keep": [
         {
           "repo": "wardsparadox-recipes",
           "rel_path": "Ghostty/Ghostty.download.recipe.yaml",
-          "identifier": "com.github.autopkg.wardsparadox.download.Ghostty",
-          "has_codesig": true,
-          "has_endofcheck": true,
-          "has_arch_var": false,
-          "source_type": "url"
+          "reason": "Canonical recipe per ownership-transfer note; 4 downstream dependents across two repos"
         }
-      ]
+      ],
+      "deprecate": [
+        {
+          "repo": "dataJAR-recipes",
+          "rel_path": "Ghostty/Ghostty.download.recipe",
+          "reason": "Functionally equivalent (same URLTextSearcher pattern, same code requirement) but only 1 dependent and no ownership signal"
+        }
+      ],
+      "rationale": [
+        {
+          "category": "shared",
+          "text": "Both scrape ghostty.org/download with URLTextSearcher to extract the release.files.ghostty.org DMG URL, both have CodeSignatureVerifier with the same com.mitchellh.ghostty / 24VZTF6M5V requirement, and both have EndOfCheckPhase."
+        },
+        {
+          "category": "favors_keep",
+          "text": "wardsparadox carries an explicit 'Originally created by @discentem, ownership transferred' comment and has 4 downstream dependents (almenscorner-recipes, wardsparadox-recipes children)."
+        },
+        {
+          "category": "favors_deprecate",
+          "text": "dataJAR has only 1 dependent and no ownership signal; the recipe-tracked first_commit (2018) appears to be a git-follow artifact rather than the actual recipe age."
+        },
+        {
+          "category": "tiebreaker",
+          "text": "dataJAR is plist (slight format preference), but dependent count and ownership note outweigh format here."
+        }
+      ],
+      "criteria": [
+        {
+          "key": "codesig",
+          "label": "CodeSignatureVerifier present",
+          "favors": null
+        },
+        {
+          "key": "endofcheck",
+          "label": "EndOfCheckPhase present",
+          "favors": null
+        },
+        {
+          "key": "source_resilience",
+          "label": "Same HTML scrape source",
+          "favors": null
+        },
+        {
+          "key": "metadata",
+          "label": "Ownership transfer note",
+          "favors": "keep"
+        },
+        {
+          "key": "format",
+          "label": "Plist vs YAML",
+          "favors": "deprecate"
+        }
+      ],
+      "deprecation_message": "Consider switching to Ghostty recipes in the wardsparadox-recipes repo. This recipe is deprecated and will be removed in the future.",
+      "dependency_impact": "1 child recipe across 1 repo"
     },
     {
       "id": "6e4fbc6fa66c",
@@ -20640,7 +20543,7 @@
         },
         {
           "repo": "rtrouton-recipes",
-          "rel_path": "AmazonCorettoJDK17/AmazonCorettoAppleSiliconJDK17.download.recipe",
+          "rel_path": "AmazonCorettoJDK17/AmazonCorettoIntelJDK17.download.recipe",
           "has_codesig": true,
           "has_endofcheck": true,
           "has_arch_var": false,
@@ -20648,7 +20551,7 @@
         },
         {
           "repo": "rtrouton-recipes",
-          "rel_path": "AmazonCorettoJDK17/AmazonCorettoIntelJDK17.download.recipe",
+          "rel_path": "AmazonCorettoJDK17/AmazonCorettoAppleSiliconJDK17.download.recipe",
           "has_codesig": true,
           "has_endofcheck": true,
           "has_arch_var": false,
@@ -20666,7 +20569,7 @@
     },
     {
       "id": "aa1cce5c4f60",
-      "app_name": "Microsoft AutoUpdate",
+      "app_name": "MicrosoftAutoUpdate",
       "action_status": "needs_pr",
       "existing_prs": [],
       "member_count": 2,
@@ -20864,24 +20767,8 @@
       "member_count": 4,
       "members_summary": [
         {
-          "repo": "apettinen-recipes",
-          "rel_path": "Brave/Brave.download.recipe",
-          "has_codesig": true,
-          "has_endofcheck": true,
-          "has_arch_var": false,
-          "dependent_count": 4
-        },
-        {
           "repo": "drewdiver-recipes",
           "rel_path": "Brave/Brave.download.recipe",
-          "has_codesig": true,
-          "has_endofcheck": true,
-          "has_arch_var": false,
-          "dependent_count": 1
-        },
-        {
-          "repo": "moofit-recipes",
-          "rel_path": "Brave/BraveUniversal.download.recipe.yaml",
           "has_codesig": true,
           "has_endofcheck": true,
           "has_arch_var": false,
@@ -20894,6 +20781,22 @@
           "has_endofcheck": true,
           "has_arch_var": false,
           "dependent_count": 3
+        },
+        {
+          "repo": "apettinen-recipes",
+          "rel_path": "Brave/Brave.download.recipe",
+          "has_codesig": true,
+          "has_endofcheck": true,
+          "has_arch_var": false,
+          "dependent_count": 4
+        },
+        {
+          "repo": "moofit-recipes",
+          "rel_path": "Brave/BraveUniversal.download.recipe.yaml",
+          "has_codesig": true,
+          "has_endofcheck": true,
+          "has_arch_var": false,
+          "dependent_count": 1
         }
       ],
       "confidence": "LOW",
@@ -21595,6 +21498,14 @@
       "member_count": 4,
       "members_summary": [
         {
+          "repo": "Lotusshaney-recipes",
+          "rel_path": "Tailscale_unstable/Tailscale_unstable.download.recipe",
+          "has_codesig": true,
+          "has_endofcheck": true,
+          "has_arch_var": false,
+          "dependent_count": 1
+        },
+        {
           "repo": "apizz-recipes",
           "rel_path": "TailScale/TailScale.download.recipe",
           "has_codesig": true,
@@ -21609,14 +21520,6 @@
           "has_endofcheck": true,
           "has_arch_var": false,
           "dependent_count": 5
-        },
-        {
-          "repo": "Lotusshaney-recipes",
-          "rel_path": "Tailscale_unstable/Tailscale_unstable.download.recipe",
-          "has_codesig": true,
-          "has_endofcheck": true,
-          "has_arch_var": false,
-          "dependent_count": 1
         },
         {
           "repo": "macprince-recipes",
@@ -21639,14 +21542,14 @@
     {
       "id": "6a68c40531bf",
       "app_name": "Vectorworks",
-      "action_status": "needs_pr",
+      "action_status": "pr_open",
       "existing_prs": [
         {
           "repo": "jazzace-recipes",
           "number": 55,
           "title": "Deprecate migrated recipes",
           "url": "https://github.com/autopkg/jazzace-recipes/pull/55",
-          "state": "closed"
+          "state": "open"
         },
         {
           "repo": "vmiller-recipes",
@@ -21660,7 +21563,23 @@
       "members_summary": [
         {
           "repo": "jazzace-recipes",
+          "rel_path": "Nemetschek/Vectorworks2024.download.recipe",
+          "has_codesig": true,
+          "has_endofcheck": true,
+          "has_arch_var": false,
+          "dependent_count": 2
+        },
+        {
+          "repo": "jazzace-recipes",
           "rel_path": "Nemetschek/VectorworksInstallManager.download.recipe",
+          "has_codesig": true,
+          "has_endofcheck": true,
+          "has_arch_var": false,
+          "dependent_count": 2
+        },
+        {
+          "repo": "vmiller-recipes",
+          "rel_path": "Nemetschek/Vectorworks2024.download.recipe",
           "has_codesig": true,
           "has_endofcheck": true,
           "has_arch_var": false,
@@ -21673,22 +21592,6 @@
           "has_endofcheck": true,
           "has_arch_var": false,
           "dependent_count": 4
-        },
-        {
-          "repo": "jazzace-recipes",
-          "rel_path": "Nemetschek/Vectorworks2024.download.recipe",
-          "has_codesig": true,
-          "has_endofcheck": true,
-          "has_arch_var": false,
-          "dependent_count": 2
-        },
-        {
-          "repo": "vmiller-recipes",
-          "rel_path": "Nemetschek/Vectorworks2024.download.recipe",
-          "has_codesig": true,
-          "has_endofcheck": true,
-          "has_arch_var": false,
-          "dependent_count": 2
         },
         {
           "repo": "vmiller-recipes",
@@ -21922,7 +21825,7 @@
     },
     {
       "id": "73ecccdc7b1a",
-      "app_name": "sipgate softphone",
+      "app_name": "sipgate-softphone",
       "action_status": "needs_pr",
       "existing_prs": [],
       "member_count": 2,
@@ -22490,7 +22393,7 @@
     },
     {
       "id": "8eb7f5613f96",
-      "app_name": "Topaz Photo AI",
+      "app_name": "TopazPhotoAI",
       "action_status": "resolved",
       "existing_prs": [
         {
@@ -22811,7 +22714,7 @@
     {
       "id": "8b12d6159172",
       "app_name": "WhatsApp",
-      "action_status": "needs_evaluation",
+      "action_status": "needs_pr",
       "existing_prs": [],
       "member_count": 2,
       "members_summary": [
@@ -22832,37 +22735,72 @@
           "dependent_count": 4
         }
       ],
-      "confidence": "UNEVALUATED",
-      "keep": [],
-      "deprecate": [],
-      "rationale": "",
-      "criteria": [],
-      "deprecation_message": "",
-      "dependency_impact": "",
-      "candidate_members": [
-        {
-          "repo": "gmarnin-recipes",
-          "rel_path": "WhatsApp/WhatsApp.download.recipe",
-          "identifier": "com.github.gmarnin.download.WhatsApp",
-          "has_codesig": true,
-          "has_endofcheck": true,
-          "has_arch_var": false,
-          "source_type": "url"
-        },
+      "confidence": "MEDIUM",
+      "keep": [
         {
           "repo": "scriptingosx-recipes",
           "rel_path": "WhatsAppInc/WhatsApp.download.recipe",
-          "identifier": "com.scriptingosx.download.WhatsApp",
-          "has_codesig": true,
-          "has_endofcheck": true,
-          "has_arch_var": false,
-          "source_type": "url"
+          "reason": "10 years older, 4 dependents across two repos, exposes DOWNLOAD_URL as an Input variable for easy override"
         }
-      ]
+      ],
+      "deprecate": [
+        {
+          "repo": "gmarnin-recipes",
+          "rel_path": "WhatsApp/WhatsApp.download.recipe",
+          "reason": "Functionally equivalent (same direct URL, same code requirement) but newly added (2026-04-14) with only 1 dependent"
+        }
+      ],
+      "rationale": [
+        {
+          "category": "shared",
+          "text": "Both download from web.whatsapp.com/desktop/mac_native/release/?configuration=Release, both have CodeSignatureVerifier with the same net.whatsapp.WhatsApp / 57T9237FN3 requirement, and both have EndOfCheckPhase."
+        },
+        {
+          "category": "favors_keep",
+          "text": "scriptingosx exposes DOWNLOAD_URL as an Input variable so downstream recipes can override the URL without forking; 4 downstream dependents include peshay-recipes children."
+        },
+        {
+          "category": "favors_deprecate",
+          "text": "gmarnin hardcodes the URL inside URLDownloader and was added 2026-04-14 with only 1 dependent."
+        },
+        {
+          "category": "tiebreaker",
+          "text": "scriptingosx first committed 2016-04-13; gmarnin first committed 2026-04-14 (a decade later). Both are plist."
+        }
+      ],
+      "criteria": [
+        {
+          "key": "codesig",
+          "label": "CodeSignatureVerifier present",
+          "favors": null
+        },
+        {
+          "key": "endofcheck",
+          "label": "EndOfCheckPhase present",
+          "favors": null
+        },
+        {
+          "key": "source_resilience",
+          "label": "Same direct URL source",
+          "favors": null
+        },
+        {
+          "key": "metadata",
+          "label": "DOWNLOAD_URL exposed as Input",
+          "favors": "keep"
+        },
+        {
+          "key": "history",
+          "label": "Earlier first commit (2016 vs 2026)",
+          "favors": "keep"
+        }
+      ],
+      "deprecation_message": "Consider switching to WhatsApp recipes in the scriptingosx-recipes repo. This recipe is deprecated and will be removed in the future.",
+      "dependency_impact": "none"
     },
     {
       "id": "1c28094cf005",
-      "app_name": "4KVideoDownloaderPlus",
+      "app_name": "4K Video Downloader Plus",
       "action_status": "needs_pr",
       "existing_prs": [],
       "member_count": 2,
@@ -23254,7 +23192,7 @@
     },
     {
       "id": "acccf736bbe4",
-      "app_name": "FabFilterProC2",
+      "app_name": "FabFilter Pro-C 2",
       "action_status": "needs_pr",
       "existing_prs": [],
       "member_count": 2,
@@ -23442,7 +23380,7 @@
     },
     {
       "id": "9d9956a109b2",
-      "app_name": "FinalDraft12",
+      "app_name": "Final Draft 12",
       "action_status": "needs_pr",
       "existing_prs": [],
       "member_count": 2,
@@ -23541,37 +23479,8 @@
     {
       "id": "66c8ae2b2df6",
       "app_name": "GIMP",
-      "action_status": "needs_evaluation",
-      "existing_prs": [
-        {
-          "repo": "hjuutilainen-recipes",
-          "number": 235,
-          "title": "Fixes URL change",
-          "url": "https://github.com/autopkg/hjuutilainen-recipes/pull/235",
-          "state": "merged"
-        },
-        {
-          "repo": "moofit-recipes",
-          "number": 237,
-          "title": "Changes to recipes",
-          "url": "https://github.com/autopkg/moofit-recipes/pull/237",
-          "state": "merged"
-        },
-        {
-          "repo": "moofit-recipes",
-          "number": 236,
-          "title": "Changes to the download and parent GIMP recipes",
-          "url": "https://github.com/autopkg/moofit-recipes/pull/236",
-          "state": "closed"
-        },
-        {
-          "repo": "moofit-recipes",
-          "number": 214,
-          "title": "Download URLs have changed slightly in GimpUniversal.download.recipe",
-          "url": "https://github.com/autopkg/moofit-recipes/pull/214",
-          "state": "closed"
-        }
-      ],
+      "action_status": "needs_pr",
+      "existing_prs": [],
       "member_count": 3,
       "members_summary": [
         {
@@ -23599,42 +23508,14 @@
           "dependent_count": 1
         }
       ],
-      "confidence": "UNEVALUATED",
+      "confidence": "SKIP",
+      "skip_reason": "Different patterns: hjuutilainen-recipes ships a single-arch download parameterized by an ARCH input variable, while MLBZ521-recipes and moofit-recipes ship pseudo-universal recipes that download both arm64 and x86_64 DMGs in one run for downstream combined packaging. GIMP does not publish a true universal binary, so per the evaluation rules pseudo-universal variants are ignored when comparing \u2014 leaving the hjuutilainen recipe with no like-for-like duplicate.",
       "keep": [],
       "deprecate": [],
       "rationale": "",
       "criteria": [],
       "deprecation_message": "",
-      "dependency_impact": "",
-      "candidate_members": [
-        {
-          "repo": "MLBZ521-recipes",
-          "rel_path": "GIMP/GIMP-Universal.download.recipe.yaml",
-          "identifier": "com.github.mlbz521.download.GIMP-Universal",
-          "has_codesig": true,
-          "has_endofcheck": true,
-          "has_arch_var": true,
-          "source_type": "url"
-        },
-        {
-          "repo": "hjuutilainen-recipes",
-          "rel_path": "GIMP/GIMP.download.recipe",
-          "identifier": "io.github.hjuutilainen.download.GIMP",
-          "has_codesig": true,
-          "has_endofcheck": true,
-          "has_arch_var": true,
-          "source_type": "url"
-        },
-        {
-          "repo": "moofit-recipes",
-          "rel_path": "GIMP/GimpUniversal.download.recipe.yaml",
-          "identifier": "com.github.moofit-recipes.download.gimp",
-          "has_codesig": true,
-          "has_endofcheck": true,
-          "has_arch_var": false,
-          "source_type": "url"
-        }
-      ]
+      "dependency_impact": ""
     },
     {
       "id": "baabd71d2eb0",
@@ -24445,20 +24326,20 @@
           "dependent_count": 1
         },
         {
-          "repo": "homebysix-recipes",
-          "rel_path": "TableauReader/TableauReader.download.recipe",
-          "has_codesig": true,
-          "has_endofcheck": true,
-          "has_arch_var": false,
-          "dependent_count": 1
-        },
-        {
           "repo": "foigus-recipes",
           "rel_path": "Tableau/TableauReader.download.recipe",
           "has_codesig": true,
           "has_endofcheck": true,
           "has_arch_var": false,
           "dependent_count": 2
+        },
+        {
+          "repo": "homebysix-recipes",
+          "rel_path": "TableauReader/TableauReader.download.recipe",
+          "has_codesig": true,
+          "has_endofcheck": true,
+          "has_arch_var": false,
+          "dependent_count": 1
         }
       ],
       "confidence": "MEDIUM",
@@ -24625,20 +24506,20 @@
           "dependent_count": 2
         },
         {
-          "repo": "nstrauss-recipes",
-          "rel_path": "Wireshark/Wireshark.download.recipe",
-          "has_codesig": true,
-          "has_endofcheck": true,
-          "has_arch_var": false,
-          "dependent_count": 3
-        },
-        {
           "repo": "justinrummel-recipes",
           "rel_path": "WiresharkDev/WiresharkDev.download.recipe",
           "has_codesig": true,
           "has_endofcheck": true,
           "has_arch_var": true,
           "dependent_count": 1
+        },
+        {
+          "repo": "nstrauss-recipes",
+          "rel_path": "Wireshark/Wireshark.download.recipe",
+          "has_codesig": true,
+          "has_endofcheck": true,
+          "has_arch_var": false,
+          "dependent_count": 3
         }
       ],
       "confidence": "SKIP",

--- a/scripts/build_candidates.py
+++ b/scripts/build_candidates.py
@@ -224,6 +224,41 @@ def git_first_commit(filepath, base):
         return None
 
 
+def find_worktree_dirs(base):
+    """Find directories under base whose .git is a file (i.e. git worktrees).
+
+    Stops descending at any repo boundary (.git file or directory) to avoid
+    walking through repo internals.
+    """
+    worktree_dirs = set()
+
+    def walk(d):
+        try:
+            entries = list(os.scandir(d))
+        except OSError:
+            return
+        for entry in entries:
+            if entry.name == ".git":
+                if entry.is_file(follow_symlinks=False):
+                    worktree_dirs.add(d)
+                return
+        for entry in entries:
+            if entry.is_dir(follow_symlinks=False):
+                walk(entry.path)
+
+    walk(str(base))
+    return worktree_dirs
+
+
+def is_under_any(filepath, dirs):
+    fp = os.path.abspath(filepath)
+    for d in dirs:
+        prefix = d if d.endswith(os.sep) else d + os.sep
+        if fp.startswith(prefix):
+            return True
+    return False
+
+
 def build_parent_index(all_recipe_files, base):
     """Build a one-pass index of ParentRecipe -> list of (repo,) for dependent counting."""
     index = defaultdict(lambda: {"count": 0, "repos": set()})
@@ -273,10 +308,18 @@ def main():
 
     base = args.repos_dir
 
+    # Identify git worktrees so we can exclude them — they duplicate recipes
+    # already counted in the primary clone.
+    worktree_dirs = find_worktree_dirs(base)
+    if worktree_dirs:
+        print(f"Excluding {len(worktree_dirs)} git worktree(s)", file=sys.stderr)
+
     # Find all recipe files (not just download) for dependent counting
     all_recipe_files = []
     for pattern in ["**/*.recipe", "**/*.recipe.yaml", "**/*.recipe.plist"]:
         all_recipe_files.extend(glob.glob(str(base / pattern), recursive=True))
+    if worktree_dirs:
+        all_recipe_files = [fp for fp in all_recipe_files if not is_under_any(fp, worktree_dirs)]
     print(f"Found {len(all_recipe_files)} total recipe files", file=sys.stderr)
 
     # Find download recipes
@@ -288,6 +331,8 @@ def main():
     all_files = []
     for pat in dl_patterns:
         all_files.extend(glob.glob(pat, recursive=True))
+    if worktree_dirs:
+        all_files = [fp for fp in all_files if not is_under_any(fp, worktree_dirs)]
     print(f"Found {len(all_files)} download recipe files", file=sys.stderr)
 
     # Parse and categorize (single pass over Process list per recipe)


### PR DESCRIPTION
## Summary
- `scripts/build_candidates.py` now skips git worktrees (directories whose `.git` is a file pointer) so phantom duplicates from local dev worktrees stop polluting candidate sets. Without this fix, 655 of 882 candidate sets were polluted and 623 existed only because of worktree dupes.
- After regenerating, candidate sets dropped from 882 → 259 (real candidates).
- `data/evaluations/2026-04-24.json` adds today's evaluations: 255 reused from `2026-04-05.json` (set IDs unchanged because they're content-hashed by member identifiers) plus 4 new sets evaluated this run: Contour, Ghostty, WhatsApp (recommend), GIMP (skip — pseudo-universal vs single-arch are not redundant).
- `docs/dashboard.json` rebuilt from the new evaluation set: 259 sets (28 HIGH, 77 MEDIUM, 111 LOW, 43 SKIP, 29 resolved).

## Test plan
- [x] Confirm `scripts/build_candidates.py --repos-dir <dir>` prints `Excluding N git worktree(s)` when worktrees are present and `Found N download recipe files` reflects the trimmed list.
- [x] Spot-check the 4 new evaluations (Contour, Ghostty, WhatsApp, GIMP) in the rendered dashboard.
- [x] Confirm the dashboard counts (259 sets / 28 HIGH / 77 MEDIUM / 111 LOW / 43 SKIP / 29 resolved) match what the dashboard renders.